### PR TITLE
feat: implement useCategory composable for menu items, breadcrumbs

### DIFF
--- a/docs/guide/use-category.md
+++ b/docs/guide/use-category.md
@@ -1,0 +1,78 @@
+# useCategory
+
+## Features
+`useCategory` composable is responsible for fetching a list of categories. A common usage scenario for this composable is navigation.
+
+## API
+```typescript
+export interface Category {
+  id: string
+  name: string;
+  primaryParentCategoryId: string;
+  definitionName: string;
+  sequenceNumber: number;
+}
+```
+
+### `search`
+Function that gets the `categories` for configured Scope.
+
+### `categories`
+Returns an array of categories fetched by `search` method as a `Category[]` property.
+
+### `loading`
+Returns the current state of `search` as `computed` `boolean` property
+
+### `error`
+Reactive object containing the error message, if search failed for any reason.
+
+## Getters
+````typescript
+interface CategoryGetters<Category> {
+  getTree: (categories: Category[]) => AgnosticCategoryTree | null;
+  getBreadcrumbs: (categories: Category[], currentCategory?: string) => AgnosticBreadcrumb[];
+  getCategoryTree?: (
+    categories: Category[],
+    currentCategory: string,
+    level: number
+  ) => AgnosticCategoryTree | null;
+}
+
+export interface AgnosticBreadcrumb {
+  text: string;
+  link: string;
+}
+
+export interface AgnosticCategoryTree {
+  label: string;
+  slug?: string;
+  items: AgnosticCategoryTree[];
+  isCurrent: boolean;
+  count?: number;
+  [x: string]: unknown;
+}
+````
+## Example
+
+```javascript
+import { onSSR } from '@vue-storefront/core';
+import { useCategory, categoryGetters } from '@vue-storefront/orc-vsf';
+
+export default {
+  setup () {
+    const { categories, search, loading } = useCategory('menuCategories');
+    const menus = computed(() => categoryGetters.getCategoryTree(categories.value, '', 1)?.items);
+    const breadcrumbs = computed(() => categoryGetters.getBreadcrumbs(categories.value, product.category));
+
+    onSSR(async () => {
+      await search({});
+    });
+
+    return {
+      menus,
+      breadcrumbs,
+      loading
+    }
+  }
+}
+```

--- a/packages/api-client/src/api/getCategory/index.ts
+++ b/packages/api-client/src/api/getCategory/index.ts
@@ -5,16 +5,14 @@ import { CustomQuery } from '@vue-storefront/core';
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export default async function getCategory(context, params, customQuery?: CustomQuery) {
 
-  // Use the built-in function
-  if (params.slug !== '') {
-    return context.client.collection.fetchByHandle(params.slug).then((collection) => {
-      // Collection with all default fields
-      return collection;
-    });
-  } else {
-    return context.client.collection.fetchAll().then((collection) => {
-      // Collection with all default fields
-      return collection;
-    });
-  }
+  const { api, scope } = context.config;
+  const { locale } = params;
+  const url = new URL(
+    `/api/categories/v2/${scope}?CultureName=${locale}`,
+    api.url
+  );
+
+  const { data } = await context.client.get(url.href);
+
+  return data ? data.categories.map(c => ({ name: c.displayName[locale], ...c })) : [];
 }

--- a/packages/api-client/src/api/getProduct/index.ts
+++ b/packages/api-client/src/api/getProduct/index.ts
@@ -12,8 +12,6 @@ export default async function getProduct(
   const { id, catId, categorySlug, page, itemsPerPage, locale } = params;
   const { api, scope, inventoryLocationIds, searchConfig } = context.config;
   let url = null;
-  console.log('I am in getProduct');
-  console.log(params);
 
   if (id) {
 
@@ -30,13 +28,17 @@ export default async function getProduct(
       ScopeId: scope
     });
 
-    return { ...productData, ...{ description: productData.description[locale] }, name: productData.displayName[locale], prices: { ...pricesData[0] } };
+    return {
+      ...productData,
+      ...{ description: productData.description[locale] },
+      name: productData.displayName[locale],
+      prices: { ...pricesData[0] }
+    };
 
   } else if (catId) {
     console.log('TODO: Related');
     return [];
   } else if (categorySlug) {
-    console.log('CategoryPage');
     url = new URL(
       `/api/search/${scope}/${locale}/availableProducts/byCategory/${categorySlug}`,
       api.url

--- a/packages/api-client/src/types.ts
+++ b/packages/api-client/src/types.ts
@@ -10,7 +10,17 @@ export type Cart = TODO;
 
 export type CartItem = TODO;
 
-export type Category = TODO;
+export type Category = {
+    id: string,
+    name: string,
+    primaryParentCategoryId: string,
+    definitionName: string,
+    sequenceNumber: number,
+    catalogId: string,
+    displayName: any,
+    includeInSearch: boolean,
+    productCount: number
+};
 
 export type Coupon = TODO;
 

--- a/packages/composables/src/getters/categoryGetters.ts
+++ b/packages/composables/src/getters/categoryGetters.ts
@@ -1,16 +1,53 @@
-import { CategoryGetters, AgnosticCategoryTree } from '@vue-storefront/core';
+import { CategoryGetters, AgnosticCategoryTree, AgnosticBreadcrumb } from '@vue-storefront/core';
 import type { Category } from '@vue-storefront/orc-vsf-api';
+import { buildCategoryTree } from '../helpers/buildCategoryTree';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-function getTree(category: Category): AgnosticCategoryTree {
-  return {
-    label: '',
-    slug: '',
-    items: [],
-    isCurrent: false
-  };
+function getTree(categories: Category[]): AgnosticCategoryTree {
+  if (!categories) {
+    return null;
+  }
+  return buildCategoryTree(categories, 'Root', '');
 }
 
-export const categoryGetters: CategoryGetters<Category> = {
-  getTree
+function getCategoryTree(
+  categories: Category[],
+  currentCategory = '',
+  level: -1,
+  withProducts = false
+): AgnosticCategoryTree | null {
+  return categories
+    ? buildCategoryTree(categories, 'Root', currentCategory, level)
+    : null;
+}
+
+function getBreadcrumbs(categories: Category[], currentCategory?: string): AgnosticBreadcrumb[] {
+  let breadcrumbs = [];
+
+  if (!categories || !currentCategory) {
+    return [];
+  }
+
+  let findCategory = (id: string) => {
+    let category = categories.find(c => c.id === id);
+    if (category) {
+      breadcrumbs.push({
+        text: category.name,
+        link: `/c/${category.id}`
+      } as AgnosticBreadcrumb);
+      if (category.primaryParentCategoryId !== 'Root') {
+        findCategory(category.primaryParentCategoryId);
+      }
+    }
+  }
+
+  findCategory(currentCategory);
+
+  return breadcrumbs.reverse();
+}
+
+export const categoryGetters: CategoryGetters<Category[]> = {
+  getTree,
+  getBreadcrumbs,
+  getCategoryTree
 };

--- a/packages/composables/src/getters/productGetters.ts
+++ b/packages/composables/src/getters/productGetters.ts
@@ -8,7 +8,7 @@ import type { Product, ProductFilter } from '@vue-storefront/orc-vsf-api';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getName(product: Product): string {
-  return product.name ?? product?.propertyBag?.DisplayName;
+  return product?.name ?? product?.propertyBag?.DisplayName;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/composables/src/helpers/buildCategoryTree.ts
+++ b/packages/composables/src/helpers/buildCategoryTree.ts
@@ -1,0 +1,39 @@
+import type { Category } from '@vue-storefront/orc-vsf-api';
+import { AgnosticCategoryTree } from '@vue-storefront/core';
+
+export const buildCategoryTree = (categories: Category[], rootCategory: string, currentCategory: string, level = -1): AgnosticCategoryTree => {
+  const root: Category = categories.find(c => c.id === rootCategory);
+  if (!root) return null;
+  const nextLevel = level > 0 ? (level - 1) : level;
+
+  const children: Category[] = categories.filter(c => c.primaryParentCategoryId === root.id);
+  const hasChildren = children.length > 0;
+  const isCurrent = root.id === currentCategory;
+  const label = root.name;
+  const slug = root.id;
+
+  const childrenUid = hasChildren
+    ? children
+      .reduce((acc, curr) => [...acc, curr.id], [])
+    : [];
+
+  const childProductCount = hasChildren
+    ? children
+      .reduce((acc, curr) => acc + curr.productCount, 0)
+    : 0;
+
+  const items = hasChildren && level !== 0
+    ? children
+    //  .filter((c) => (withProducts ? c.productCount > 0 : true))
+      .map((c) => buildCategoryTree(categories, c.id, currentCategory, nextLevel))
+    : [];
+
+  return {
+    label,
+    slug,
+    uid: [root.id, ...childrenUid],
+    items: items,
+    count: childProductCount || root.productCount,
+    isCurrent
+  };
+};

--- a/packages/composables/src/useCategory/index.ts
+++ b/packages/composables/src/useCategory/index.ts
@@ -8,32 +8,13 @@ import type {
   UseCategorySearchParams as SearchParams
 } from '../types';
 
-const params: UseCategoryFactoryParams<Category, SearchParams> = {
+const params: UseCategoryFactoryParams<Category[], SearchParams> = {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   categorySearch: async (context: Context, { customQuery, ...params }) => {
-    console.log('Mocked: useCategory.categorySearch');
-
-    return [
-      {
-        id: 1,
-        name: 'Women',
-        slug: 'women',
-        items: []
-      },
-      {
-        id: 2,
-        name: 'Men',
-        slug: 'men',
-        items: []
-      },
-      {
-        id: 3,
-        name: 'Kids',
-        slug: 'kids',
-        items: []
-      }
-    ];
+    const app: any = context.$occ.config.app;
+    const locale: any = app.i18n.locale;
+    return await context.$occ.api.getCategory({ ...params, locale }, customQuery);
   }
 };
 
-export const useCategory = useCategoryFactory<Category, SearchParams>(params);
+export const useCategory = useCategoryFactory<Category[], SearchParams>(params);

--- a/packages/theme/components/HeaderNavigation.vue
+++ b/packages/theme/components/HeaderNavigation.vue
@@ -1,0 +1,84 @@
+<template>
+  <div class="sf-header__navigation desktop" v-if="!isMobile">
+    <SfHeaderNavigationItem
+      v-for="(menu, index) in menus"
+      :key="index"
+      class="nav-item"
+      v-e2e="`app-header-url_${menu.slug}`"
+      :label="menu.label"
+      :link="localePath(`/c/${menu.slug}`)"
+    />
+  </div>
+  <SfModal v-else :visible="isMobileMenuOpen">
+    <SfHeaderNavigationItem
+      v-for="(menu, index) in menus"
+      :key="index"
+      class="nav-item"
+      v-e2e="`app-header-url_${menu.slug}`"
+    >
+      <template #mobile-navigation-item>
+        <SfMenuItem
+          :label="menu.label"
+          class="sf-header-navigation-item__menu-item"
+          :link="localePath(`/c/${menu.slug}`)"
+          @click="toggleMobileMenu"
+        />
+      </template>
+    </SfHeaderNavigationItem>
+  </SfModal>
+</template>
+
+<script>
+import { SfMenuItem, SfModal } from '@storefront-ui/vue';
+import { useUiState } from '~/composables';
+import { useCategory, categoryGetters } from '@vue-storefront/orc-vsf';
+import { computed } from '@nuxtjs/composition-api';
+import { onSSR } from '@vue-storefront/core';
+
+export default {
+  name: 'HeaderNavigation',
+  components: {
+    SfMenuItem,
+    SfModal
+  },
+  props: {
+    isMobile: {
+      type: Boolean,
+      default: false
+    }
+  },
+  setup() {
+    const { isMobileMenuOpen, toggleMobileMenu } = useUiState();
+    const { search: searchCategories, categories, loading } = useCategory('categories');
+
+    onSSR(async () => {
+      await searchCategories({});
+    });
+
+    const menus = computed(() => categoryGetters.getCategoryTree(categories.value, '', 1)?.items.slice(0, 5));
+
+    return {
+      menus,
+      loading,
+      isMobileMenuOpen,
+      toggleMobileMenu
+    };
+  }
+};
+</script>
+
+<style lang="scss" scoped>
+.sf-header-navigation-item {
+  ::v-deep &__item--mobile {
+    display: block;
+  }
+}
+.sf-modal {
+  ::v-deep &__bar {
+    display: none;
+  }
+  ::v-deep &__content {
+    padding: var(--modal-content-padding, var(--spacer-base) 0);
+  }
+}
+</style>

--- a/packages/theme/pages/Product.vue
+++ b/packages/theme/pages/Product.vue
@@ -1,127 +1,122 @@
 <template>
-  <div id="product">
-    <SfBreadcrumbs
-      class="breadcrumbs desktop-only"
-      :breadcrumbs="breadcrumbs"
-    />
-    <div class="product">
-      <LazyHydrate when-idle>
-        <SfGallery :images="productGallery" class="product__gallery" />
-      </LazyHydrate>
+  <SfLoader
+    :class="{ 'loading': productLoading }"
+    :loading="productLoading">
+    <div id="product">
+      <SfBreadcrumbs
+        class="breadcrumbs desktop-only"
+        :breadcrumbs="breadcrumbs"
+      />
+      <div class="product">
+        <LazyHydrate when-idle>
+          <SfGallery :images="productGallery" class="product__gallery" />
+        </LazyHydrate>
 
-      <div class="product__info">
-        <div class="product__header">
-          <SfHeading
-            :title="productGetters.getName(product)"
-            :level="3"
-            class="sf-heading--no-underline sf-heading--left"
-          />
-          <SfIcon
-            icon="drag"
-            size="xxl"
-            color="var(--c-text-disabled)"
-            class="product__drag-icon smartphone-only"
-          />
-        </div>
-        <div class="product__price-and-rating">
-          <SfPrice
-            :regular="$n(productGetters.getPrice(product).regular, 'currency')"
-            :special="productGetters.getPrice(product).special && $n(productGetters.getPrice(product).special, 'currency')"
-          />
-        </div>
-        <div>
-          <SfSelect
-            v-e2e="'size-select'"
-            v-if="options.size"
-            :value="configuration.size"
-            @input="size => updateFilter({ size })"
-            label="Size"
-            class="sf-select--underlined product__select-size"
-            :required="true"
-          >
-            <SfSelectOption
-              v-for="size in options.size"
-              :key="size.value"
-              :value="size.value"
-            >
-              {{size.label}}
-            </SfSelectOption>
-          </SfSelect>
-          <div v-if="options.color && options.color.length > 1" class="product__colors desktop-only">
-            <p class="product__color-label">{{ $t('Color') }}:</p>
-            <SfColor
-              v-for="(color, i) in options.color"
-              :key="i"
-              :color="color.value"
-              class="product__color"
-              @click="updateFilter({ color: color.value })"
+        <div class="product__info">
+          <div class="product__header">
+            <SfHeading
+              :title="productGetters.getName(product)"
+              :level="3"
+              class="sf-heading--no-underline sf-heading--left"
+            />
+            <SfIcon
+              icon="drag"
+              size="xxl"
+              color="var(--c-text-disabled)"
+              class="product__drag-icon smartphone-only"
             />
           </div>
-          <SfAddToCart
-            v-e2e="'product_add-to-cart'"
-            :stock="stock"
-            v-model="qty"
-            :disabled="loading"
-            :canAddToCart="stock > 0"
-            class="product__add-to-cart"
-            @click="addItem({ product, quantity: parseInt(qty) })"
-          />
-        </div>
-
-        <LazyHydrate when-idle>
-          <SfTabs :open-tab="1" class="product__tabs">
-            <SfTab title="Description">
-              <div v-html="productGetters.getDescription(product)" class="product__description">
-              </div>
-              <SfProperty
-                v-for="(property, i) in properties"
-                :key="i"
-                :name="property.name"
-                :value="property.value"
-                class="product__property"
-              >
-                <template v-if="property.name === 'Category'" #value>
-                  <SfButton class="product__property__button sf-button--text">
-                    {{ property.value }}
-                  </SfButton>
-                </template>
-              </SfProperty>
-            </SfTab>
-            <SfTab
-              title="Additional Information"
-              class="product__additional-info"
+          <div class="product__price-and-rating">
+            <SfPrice
+              :regular="$n(productGetters.getPrice(product).regular, 'currency')"
+              :special="productGetters.getPrice(product).special && $n(productGetters.getPrice(product).special, 'currency')"
+            />
+          </div>
+          <div>
+            <SfSelect
+              v-e2e="'size-select'"
+              v-if="options.size"
+              :value="configuration.size"
+              @input="size => updateFilter({ size })"
+              label="Size"
+              class="sf-select--underlined product__select-size"
+              :required="true"
             >
-            <div class="product__additional-info">
-              <p class="product__additional-info__title">{{ $t('Brand') }}</p>
-              <p>{{ brand }}</p>
-              <p class="product__additional-info__title">{{ $t('Instruction1') }}</p>
-              <p class="product__additional-info__paragraph">
-                {{ $t('Instruction2') }}
-              </p>
-              <p class="product__additional-info__paragraph">
-                {{ $t('Instruction3') }}
-              </p>
-              <p>{{ careInstructions }}</p>
+              <SfSelectOption
+                v-for="size in options.size"
+                :key="size.value"
+                :value="size.value"
+              >
+                {{size.label}}
+              </SfSelectOption>
+            </SfSelect>
+            <div v-if="options.color && options.color.length > 1" class="product__colors desktop-only">
+              <p class="product__color-label">{{ $t('Color') }}:</p>
+              <SfColor
+                v-for="(color, i) in options.color"
+                :key="i"
+                :color="color.value"
+                class="product__color"
+                @click="updateFilter({ color: color.value })"
+              />
             </div>
-            </SfTab>
-          </SfTabs>
-        </LazyHydrate>
+            <SfAddToCart
+              v-e2e="'product_add-to-cart'"
+              :stock="stock"
+              v-model="qty"
+              :disabled="loading"
+              :canAddToCart="stock > 0"
+              class="product__add-to-cart"
+              @click="addItem({ product, quantity: parseInt(qty) })"
+            />
+          </div>
+
+          <LazyHydrate when-idle>
+            <SfTabs :open-tab="1" class="product__tabs">
+              <SfTab title="Description">
+                <div v-html="productGetters.getDescription(product)" class="product__description">
+                </div>
+                <SfProperty
+                  name="Category"
+                  :value="breadcrumbs[breadcrumbs.length - 1].text"
+                  class="product__property"
+                />
+              </SfTab>
+              <SfTab
+                title="Additional Information"
+                class="product__additional-info"
+              >
+              <div class="product__additional-info">
+                <p class="product__additional-info__title">{{ $t('Brand') }}</p>
+                <p>{{ brand }}</p>
+                <p class="product__additional-info__title">{{ $t('Instruction1') }}</p>
+                <p class="product__additional-info__paragraph">
+                  {{ $t('Instruction2') }}
+                </p>
+                <p class="product__additional-info__paragraph">
+                  {{ $t('Instruction3') }}
+                </p>
+                <p>{{ careInstructions }}</p>
+              </div>
+              </SfTab>
+            </SfTabs>
+          </LazyHydrate>
+        </div>
       </div>
+
+      <LazyHydrate when-visible>
+        <RelatedProducts
+          :products="relatedProducts"
+          :loading="relatedLoading"
+          title="Match it with"
+        />
+      </LazyHydrate>
+
+      <LazyHydrate when-visible>
+        <InstagramFeed />
+      </LazyHydrate>
     </div>
-
-    <LazyHydrate when-visible>
-      <RelatedProducts
-        :products="relatedProducts"
-        :loading="relatedLoading"
-        title="Match it with"
-      />
-    </LazyHydrate>
-
-    <LazyHydrate when-visible>
-      <InstagramFeed />
-    </LazyHydrate>
-
-  </div>
+  </SfLoader>
 </template>
 <script>
 import {
@@ -141,13 +136,14 @@ import {
   SfReview,
   SfBreadcrumbs,
   SfButton,
-  SfColor
+  SfColor,
+  SfLoader
 } from '@storefront-ui/vue';
 
 import InstagramFeed from '~/components/InstagramFeed.vue';
 import RelatedProducts from '~/components/RelatedProducts.vue';
 import { ref, computed, useRoute, useRouter } from '@nuxtjs/composition-api';
-import { useProduct, useCart, productGetters, useReview, reviewGetters } from '@vue-storefront/orc-vsf';
+import { useProduct, useCart, useCategory, categoriesGetters, productGetters, useReview, reviewGetters, categoryGetters } from '@vue-storefront/orc-vsf';
 import { onSSR } from '@vue-storefront/core';
 import LazyHydrate from 'vue-lazy-hydration';
 import { addBasePath } from '@vue-storefront/core';
@@ -159,20 +155,19 @@ export default {
     const qty = ref(1);
     const route = useRoute();
     const router = useRouter();
-    const { products, search } = useProduct('products');
+    const { search: searchCategories, categories } = useCategory('categories');
+    const { products, search, loading: productLoading } = useProduct('products');
     const { products: relatedProducts, search: searchRelatedProducts, loading: relatedLoading } = useProduct('relatedProducts');
     const { addItem, loading } = useCart();
-    const { reviews: productReviews, search: searchReviews } = useReview('productReviews');
 
     const id = computed(() => route.value.params.id);
     const product = computed(() => productGetters.getFiltered(products.value, { master: true, attributes: route.value.query })[0]);
     const options = computed(() => productGetters.getAttributes(products.value, ['color', 'size']));
     const configuration = computed(() => productGetters.getAttributes(product.value, ['color', 'size']));
-    const categories = computed(() => productGetters.getCategoryIds(product.value));
+    const productCategories = computed(() => productGetters.getCategoryIds(product.value));
     const reviews = computed(() => reviewGetters.getItems(productReviews.value));
 
-    // TODO: Breadcrumbs are temporary disabled because productGetters return undefined. We have a mocks in data
-    // const breadcrumbs = computed(() => productGetters.getBreadcrumbs ? productGetters.getBreadcrumbs(product.value) : props.fallbackBreadcrumbs);
+    const breadcrumbs = computed(() => categoryGetters.getBreadcrumbs(categories.value, productCategories.value[0]));
     const productGallery = computed(() => productGetters.getGallery(product.value).map(img => ({
       mobile: { url: addBasePath(img.small) },
       desktop: { url: addBasePath(img.normal) },
@@ -182,8 +177,7 @@ export default {
 
     onSSR(async () => {
       await search({ id: id.value });
-      await searchRelatedProducts({ catId: [categories.value[0]], limit: 8 });
-      await searchReviews({ productId: id.value });
+      await searchRelatedProducts({ catId: [productCategories.value[0]], limit: 8 });
     });
 
     const updateFilter = (filter) => {
@@ -197,19 +191,17 @@ export default {
     };
 
     return {
+      breadcrumbs,
       updateFilter,
       configuration,
       product,
-      reviews,
-      reviewGetters,
-      averageRating: computed(() => productGetters.getAverageRating(product.value)),
-      totalReviews: computed(() => productGetters.getTotalReviews(product.value)),
       relatedProducts: computed(() => productGetters.getFiltered(relatedProducts.value, { master: true })),
       relatedLoading,
       options,
       qty,
       addItem,
       loading,
+      productLoading,
       productGetters,
       productGallery
     };
@@ -229,12 +221,12 @@ export default {
     SfImage,
     SfBanner,
     SfSticky,
-    SfReview,
     SfBreadcrumbs,
     SfButton,
     InstagramFeed,
     RelatedProducts,
-    LazyHydrate
+    LazyHydrate,
+    SfLoader
   },
   data() {
     return {
@@ -261,27 +253,7 @@ export default {
       detailsIsActive: false,
       brand:
           'Brand name is the perfect pairing of quality and design. This label creates major everyday vibes with its collection of modern brooches, silver and gold jewellery, or clips it back with hair accessories in geo styles.',
-      careInstructions: 'Do not wash!',
-      breadcrumbs: [
-        {
-          text: 'Home',
-          route: {
-            link: '#'
-          }
-        },
-        {
-          text: 'Category',
-          route: {
-            link: '#'
-          }
-        },
-        {
-          text: 'Pants',
-          route: {
-            link: '#'
-          }
-        }
-      ]
+      careInstructions: 'Do not wash!'
     };
   }
 };


### PR DESCRIPTION
implement useCategory composable for navigation like menu items, breadcrumbs

## Description
implement useCategory composable, categoryGetters and helper to build category tree

## Related Issue
AB#60254

## Motivation and Context
Ability to build Catrgory tree to use it for navigation

## How Has This Been Tested?
In Main Menu and Product Details Breadcrumbs

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/6649972/165706981-ed84ad41-4fd8-48e1-bdb8-07b20ff5bd5b.png)

