### PR TITLE
feat: implement useFacet composable for category pages

### DIFF
--- a/docs/guide/use-facet.md
+++ b/docs/guide/use-facet.md
@@ -1,0 +1,83 @@
+# useFacet
+
+## Features
+`useFacet` composable is responsible for fetching a data of products with facets. A common usage scenario for this composable is category pages.
+
+## API
+```typescript
+interface UseFacet<any> {
+  result: ComputedProperty<FacetSearchResult<Facet>>;
+  loading: ComputedProperty<boolean>;
+  search: (params?: AgnosticFacetSearchParams) => Promise<void>;
+  error: ComputedProperty<UseFacetErrors>;
+}
+
+export interface Facet {
+    total: any,
+    products: any,
+    facets: any,
+    categories?: Category[],
+    categoryCounts: any
+}
+
+export interface Category {
+  id: string
+  name: string;
+  primaryParentCategoryId: string;
+  definitionName: string;
+  sequenceNumber: number;
+}
+```
+
+### `search`
+Function that loading the data based on passed parameters. 
+
+### `result`
+Reactive data object containing the response from the backend.
+
+### `loading`
+Reactive object containing information about the loading state of search.
+
+### `error`
+Reactive object containing the error message, if search failed for any reason.
+
+## Getters
+````typescript
+interface FacetsGetters<Facet> {
+  getAll: (data: FacetSearchResult<Facet>, criteria?: CRITERIA) => AgnosticFacet[];
+  getGrouped: (data: FacetSearchResult<Facet>, criteria?: CRITERIA) => AgnosticGroupedFacet[];
+  getCategoryTree: (data: FacetSearchResult<Facet>, root?: string = 'Root', level = 3) => AgnosticCategoryTree;
+  getSortOptions: (data: FacetSearchResult<Facet>) => AgnosticSort;
+  getProducts: (data: FacetSearchResult<Facet>) => RESULTS;
+  getPagination: (data: FacetSearchResult<Facet>) => AgnosticPagination;
+  getBreadcrumbs: (data: FacetSearchResult<Facet>) => AgnosticBreadcrumb[];
+}
+````
+## Example
+
+```javascript
+import { onSSR } from '@vue-storefront/core';
+import { useFacet, facetGetters } from '@vue-storefront/orc-vsf';
+
+export default {
+  setup () {
+    const { result, search, loading, error } = useFacet();
+    const products = computed(() => facetGetters.getProducts(result.value));
+    const categoryTree = computed(() => facetGetters.getCategoryTree(result.value));
+    const breadcrumbs = computed(() => facetGetters.getBreadcrumbs(result.value));
+    const pagination = computed(() => facetGetters.getPagination(result.value));
+
+    onSSR(async () => {
+       await search({...th.getFacetsFromURL(), withCategoryCounts: true});
+    });
+
+    return {
+      products,
+      categoryTree,
+      breadcrumbs,
+      pagination,
+      loading
+    }
+  }
+}
+```

--- a/docs/guide/use-product.md
+++ b/docs/guide/use-product.md
@@ -1,0 +1,67 @@
+# useProduct
+
+## Features
+`useProduct` composable is responsible for fetching a list of products or product details based on `queryType` parameter. A common usage scenario for this composable is products sets and product details.
+
+## API
+```typescript
+export interface Product {
+  productId: string
+  name: string;
+  description?: any,
+  sku: string,
+  currentPrice?: any,
+  regularPrice?: any,
+  propertyBag: any,
+  parentCategoryIds: any,
+  prices?: any
+}
+```
+
+### `search`
+Function that gets the `products` or `product` based on passed `queryType` parameter. 
+
+### `products`
+Returns an array of products `Product[]` or a single product `Product` fetched by `search` method.
+
+### `loading`
+Returns the current state of `search` as `computed` `boolean` property
+
+### `error`
+Reactive object containing the error message, if search failed for any reason.
+
+## Getters
+````typescript
+interface ProductGetters<Product> {
+  getPrice: (product: Product) => AgnosticPrice;
+  getName: (product: Product) => string;
+  getDescription: (product: Product) => string; 
+}
+
+export interface AgnosticPrice {
+    regular: number | null;
+    special?: number | null;
+}
+````
+## Example
+
+```javascript
+import { onSSR } from '@vue-storefront/core';
+import { useProduct, productGetters } from '@vue-storefront/orc-vsf';
+
+export default {
+  setup () {
+    const id = computed(() => route.value.params.id);
+    const { products: product, search: searchProduct, loading } = useProduct(`product-${id}`);
+  
+    onSSR(async () => {
+        await searchProduct({ queryType: 'DETAIL', id: id.value });
+    });
+
+    return {
+      product,
+      loading
+    }
+  }
+}
+```

--- a/packages/api-client/src/api/getProduct/index.ts
+++ b/packages/api-client/src/api/getProduct/index.ts
@@ -1,80 +1,27 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { CustomQuery } from '@vue-storefront/core';
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export default async function getProduct(
   context,
-  params,
-  customQuery?: CustomQuery
+  params
 ) {
-  const { id, catId, categorySlug, page, itemsPerPage, locale } = params;
-  const { api, scope, inventoryLocationIds, searchConfig } = context.config;
-  let url = null;
+  const { id, locale } = params;
+  const { api, scope } = context.config;
+  const url = new URL(
+    `/api/products/v2/${scope}/${id}?CultureName=${locale}&IncludeMedia=true&IncludeVariants=true&IncludeImageUrl=true`,
+    api.url
+  );
+  const getPricesUrl = new URL(`/api/products/${scope}/prices`, api.url);
+  const { data: productData } = await context.client.get(url.href);
+  const { data: pricesData } = await context.client.post(getPricesUrl.href, {
+    ProductIds: [id],
+    IncludeVariants: true,
+    ScopeId: scope
+  });
 
-  if (id) {
-
-    url = new URL(
-      `/api/products/v2/${scope}/${id}?CultureName=${locale}&IncludeMedia=true&IncludeVariants=true&IncludeImageUrl=true`,
-      api.url
-    );
-
-    const getPricesUrl = new URL(`/api/products/${scope}/prices`, api.url);
-    const { data: productData } = await context.client.get(url.href);
-    const { data: pricesData } = await context.client.post(getPricesUrl.href, {
-      ProductIds: [id],
-      IncludeVariants: true,
-      ScopeId: scope
-    });
-
-    return {
-      ...productData,
-      ...{ description: productData.description[locale] },
-      name: productData.displayName[locale],
-      prices: { ...pricesData[0] }
-    };
-
-  } else if (catId) {
-    console.log('TODO: Related');
-    return [];
-  } else if (categorySlug) {
-    url = new URL(
-      `/api/search/${scope}/${locale}/availableProducts/byCategory/${categorySlug}`,
-      api.url
-    );
-    const maximumItems = itemsPerPage ?? searchConfig.defaultItemsPerPage;
-    const { data } = await context.client.post(url.href, {
-      inventoryLocationIds,
-      categoryName: categorySlug,
-      query: {
-        maximumItems: maximumItems,
-        startingIndex: (page - 1) * maximumItems,
-        sortings: [
-          {
-            direction: 0,
-            propertyName: 'score'
-          }
-        ]
-      }
-    });
-
-    return { products: data.documents ?? [], total: data.totalCount };
-  } else {
-
-    url = new URL(
-      `/api/search/${scope}/${locale}/availableProducts`,
-      api.url
-    );
-
-    const { data } = await context.client.post(url.href, {
-      query: {
-        distinctResults: true,
-        maximumItems: searchConfig.defaultItemsPerPage,
-        startingIndex: 0
-      }
-    });
-
-    return data.documents ?? [];
-  }
+  return {
+    ...productData,
+    ...{ description: productData.description[locale] },
+    name: productData.displayName[locale],
+    prices: { ...pricesData[0] }
+  };
 }

--- a/packages/api-client/src/api/getProducts/index.ts
+++ b/packages/api-client/src/api/getProducts/index.ts
@@ -1,0 +1,66 @@
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+export default async function getProducts(
+  context,
+  params
+) {
+  const { catId, categorySlug, withCategoryCounts, facetPredicates, page, itemsPerPage, locale } = params;
+  const { api, scope, inventoryLocationIds, searchConfig } = context.config;
+  let url = null;
+
+  if (catId) {
+    console.log('TODO: Related');
+    return [];
+  } else if (categorySlug) {
+    let categoryCounts = [];
+    url = new URL(`/api/search/${scope}/${locale}/availableProducts/byCategory/${categorySlug}`, api.url);
+    const maximumItems = itemsPerPage ?? searchConfig.defaultItemsPerPage;
+    const { data } = await context.client.post(url.href, {
+      inventoryLocationIds,
+      categoryName: categorySlug,
+      includeFacets: true,
+      facetPredicates,
+      facets: searchConfig.availableFacets,
+      query: {
+        maximumItems: maximumItems,
+        startingIndex: (page - 1) * maximumItems,
+        sortings: [
+          {
+            direction: 0,
+            propertyName: 'score'
+          }
+        ]
+      }
+    });
+
+    if (withCategoryCounts) {
+      url = new URL(`/api/search/${scope}/${locale}/availableProducts`, api.url);
+      const { data: categoryCountsData } = await context.client.post(url.href, {
+        inventoryLocationIds,
+        includeFacets: true,
+        facets: searchConfig.categoryCountFacets,
+        query: {
+          maximumItems: 0,
+          startingIndex: 0
+        }
+      });
+
+      categoryCounts = categoryCountsData.facets;
+    }
+
+    return { products: data.documents ?? [], total: data.totalCount, facets: data.facets, categoryCounts };
+  } else {
+
+    url = new URL(`/api/search/${scope}/${locale}/availableProducts`, api.url);
+
+    const { data } = await context.client.post(url.href, {
+      query: {
+        distinctResults: true,
+        maximumItems: searchConfig.defaultItemsPerPage,
+        startingIndex: 0
+      }
+    });
+
+    return { products: data.documents ?? [], total: data.totalCount, facets: data.facets };
+  }
+}

--- a/packages/api-client/src/index.server.ts
+++ b/packages/api-client/src/index.server.ts
@@ -3,6 +3,7 @@ import type { Setttings, Endpoints } from './types';
 import axios from 'axios';
 
 import getProduct from './api/getProduct';
+import getProducts from './api/getProducts';
 import getCategory from './api/getCategory';
 
 function onCreate(settings) {
@@ -24,6 +25,7 @@ const { createApiClient } = apiClientFactory<Setttings, Endpoints>({
   onCreate,
   api: {
     getProduct,
+    getProducts,
     getCategory
   }
 });

--- a/packages/api-client/src/types.ts
+++ b/packages/api-client/src/types.ts
@@ -17,15 +17,19 @@ export type Category = {
     definitionName: string,
     sequenceNumber: number,
     catalogId: string,
-    displayName: any,
+    displayName: object,
     includeInSearch: boolean,
-    productCount: number
+    productsCount: number
 };
 
 export type Coupon = TODO;
 
 export type Facet = {
-    total: any
+    total: any,
+    products: any,
+    facets: any,
+    categories?: Category[],
+    categoryCounts?: any
 };
 
 export type FacetSearchCriteria = TODO;
@@ -37,16 +41,21 @@ export type OrderItem = TODO;
 export type PasswordResetResult = TODO;
 
 export type Product = {
-    productId: any,
+    productId: string,
     name: any,
     description?: any,
-    sku: any,
+    sku: string,
     currentPrice?: any,
     regularPrice?: any,
     propertyBag: any,
     parentCategoryIds: any,
     prices?: any
 };
+
+export const enum ProductsQueryType {
+    List = 'LIST',
+    Detail = 'DETAIL'
+}
 
 export type ProductFilter = TODO;
 

--- a/packages/composables/src/getters/categoryGetters.ts
+++ b/packages/composables/src/getters/categoryGetters.ts
@@ -20,28 +20,27 @@ function getCategoryTree(
     : null;
 }
 
-function getBreadcrumbs(categories: Category[], currentCategory?: string): AgnosticBreadcrumb[] {
+function getBreadcrumbs(categories: Category[], currentCategory?: string, includeHome = true): AgnosticBreadcrumb[] {
   const breadcrumbs = [];
 
   if (!categories || !currentCategory) {
     return [];
   }
+  let category = categories.find(c => c.id === currentCategory);
+  while (category && category.id !== 'Root') {
+    breadcrumbs.push({
+      text: category.name,
+      link: `/c/${category.id}`
+    } as AgnosticBreadcrumb);
+    category = categories.find(c => c.id === category.primaryParentCategoryId);
+  }
 
-  const findCategory = (id: string) => {
-    const category = categories.find(c => c.id === id);
-    if (category) {
-      breadcrumbs.push({
-        text: category.name,
-        link: `/c/${category.id}`
-      } as AgnosticBreadcrumb);
-      if (category.primaryParentCategoryId !== 'Root') {
-        findCategory(category.primaryParentCategoryId);
-      }
-    }
-  };
-
-  findCategory(currentCategory);
-
+  if (includeHome) {
+    return [
+      { text: 'Home', link: '/' },
+      ...breadcrumbs.reverse()
+    ];
+  }
   return breadcrumbs.reverse();
 }
 

--- a/packages/composables/src/getters/facetGetters.ts
+++ b/packages/composables/src/getters/facetGetters.ts
@@ -10,7 +10,7 @@ import {
 } from '@vue-storefront/core';
 import type { Facet, FacetSearchCriteria } from '@vue-storefront/orc-vsf-api';
 import { buildCategoryTree } from '../helpers/buildCategoryTree';
-import { fillProductCounts } from '../helpers/categoriesUtils';
+import { setProductCounts } from '../helpers/categoriesUtils';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getAll(params: FacetSearchResult<Facet>, criteria?: FacetSearchCriteria): AgnosticFacet[] {
@@ -37,7 +37,7 @@ function getCategoryTree(params: FacetSearchResult<Facet>, root = 'Root', level 
   const { categorySlug, withCategoryCounts } = params.input;
   const categories = params.data?.categories;
   if (withCategoryCounts) {
-    fillProductCounts(categories, categoryCounts);
+    setProductCounts(categories, categoryCounts);
   }
 
   return buildCategoryTree(categories, root, categorySlug, level);

--- a/packages/composables/src/getters/productGetters.ts
+++ b/packages/composables/src/getters/productGetters.ts
@@ -66,7 +66,7 @@ function getAttributes(products: Product[] | Product, filterByAttributeName?: st
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getDescription(product: Product): string {
-  return product.description;
+  return product?.description;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/composables/src/helpers/buildCategoryTree.ts
+++ b/packages/composables/src/helpers/buildCategoryTree.ts
@@ -1,7 +1,7 @@
 import type { Category } from '@vue-storefront/orc-vsf-api';
 import { AgnosticCategoryTree } from '@vue-storefront/core';
 
-export const buildCategoryTree = (categories: Category[], rootCategory: string, currentCategory: string, level = -1): AgnosticCategoryTree => {
+export const buildCategoryTree = (categories: Category[], rootCategory: string, currentCategory: string, level = -1, withProducts = false): AgnosticCategoryTree => {
   const root: Category = categories.find(c => c.id === rootCategory);
   if (!root) return null;
   const nextLevel = level > 0 ? (level - 1) : level;
@@ -19,12 +19,12 @@ export const buildCategoryTree = (categories: Category[], rootCategory: string, 
 
   const childProductCount = hasChildren
     ? children
-      .reduce((acc, curr) => acc + curr.productCount, 0)
+      .reduce((acc, curr) => acc + curr.productsCount, 0)
     : 0;
 
   const items = hasChildren && level !== 0
     ? children
-    //  .filter((c) => (withProducts ? c.productCount > 0 : true))
+      .filter((c) => (withProducts ? c.productsCount > 0 : true))
       .map((c) => buildCategoryTree(categories, c.id, currentCategory, nextLevel))
     : [];
 
@@ -33,7 +33,7 @@ export const buildCategoryTree = (categories: Category[], rootCategory: string, 
     slug,
     uid: [root.id, ...childrenUid],
     items: items,
-    count: childProductCount || root.productCount,
+    count: childProductCount || root.productsCount,
     isCurrent
   };
 };

--- a/packages/composables/src/helpers/buildFacetPredicates.ts
+++ b/packages/composables/src/helpers/buildFacetPredicates.ts
@@ -1,0 +1,29 @@
+import type { Category } from '@vue-storefront/orc-vsf-api';
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export const buildFacetPredicates = (categories: any, rootCategory: string): any => {
+  if (!Array.isArray(categories)) return [];
+  const root: Category = categories.find(c => c.id === rootCategory);
+  if (!root) return [];
+
+  const getAncestorsAndSelfCategoriesAsync = (current: Category) => {
+    const result: string[] = [];
+    while (current && current.id !== 'Root') {
+      result.push(current.name);
+      current = categories.find(c => c.id === current.primaryParentCategoryId);
+    }
+    return result.reverse();
+  };
+
+  const categoryFacets = getAncestorsAndSelfCategoriesAsync(root);
+
+  const facetPredicates = categoryFacets.map((c, index) => ({
+    facetType: 1,
+    fieldName: `CategoryLevel${index + 1}_Facet`,
+    values: [c],
+    operatorType: 0,
+    excludeFilterForFacetsCount: true
+  }));
+
+  return facetPredicates;
+};

--- a/packages/composables/src/helpers/categoriesUtils.ts
+++ b/packages/composables/src/helpers/categoriesUtils.ts
@@ -1,0 +1,25 @@
+import type { Category } from '@vue-storefront/orc-vsf-api';
+
+export const getCategoryLevel = (categories: Category[], currentCatId: string): number => {
+  let level = 1;
+  let currentCat: Category = categories.find(c => c.id === currentCatId);
+
+  while (currentCat && currentCat.id !== 'Root') {
+    currentCat = categories.find(c => c.id === currentCat.primaryParentCategoryId);
+    level++;
+  }
+
+  return level;
+};
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export const fillProductCounts = (categories: Category[], counts: any): void => {
+  if (!categories || !counts || !Array.isArray(counts)) return;
+
+  const allCountValues = counts.flatMap(c => c.values);
+
+  categories.forEach(cat => {
+    const count = allCountValues.find(c => c.value === cat.id);
+    cat.productsCount = count ? count.count : 0;
+  });
+};

--- a/packages/composables/src/helpers/categoriesUtils.ts
+++ b/packages/composables/src/helpers/categoriesUtils.ts
@@ -13,7 +13,7 @@ export const getCategoryLevel = (categories: Category[], currentCatId: string): 
 };
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-export const fillProductCounts = (categories: Category[], counts: any): void => {
+export const setProductCounts = (categories: Category[], counts: any): void => {
   if (!categories || !counts || !Array.isArray(counts)) return;
 
   const allCountValues = counts.flatMap(c => c.values);

--- a/packages/composables/src/useFacet/index.ts
+++ b/packages/composables/src/useFacet/index.ts
@@ -3,24 +3,28 @@ import {
   useFacetFactory,
   FacetSearchResult
 } from '@vue-storefront/core';
-import type {
-  UseFacetSearchParams as SearchParams
-} from '../types';
+import { AgnosticFacetSearchParams } from '@vue-storefront/core';
+import { useCategory } from '../useCategory';
+import { buildFacetPredicates } from '../helpers/buildFacetPredicates';
 
 const factoryParams = {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  search: async (context: Context, params: FacetSearchResult<SearchParams>) => {
+  search: async (context: Context, params: FacetSearchResult<AgnosticFacetSearchParams>) => {
     const app: any = context.$occ.config.app;
-
+    const { categories } = useCategory('categories');
     const { ...searchParams } = params.input;
     searchParams.locale = app.i18n.locale;
-
-    const { products, total } = await context.$occ.api.getProduct(searchParams);
+    const { categorySlug } = searchParams;
+    searchParams.facetPredicates = buildFacetPredicates(categories.value, categorySlug);
+    const { products, total, facets, categoryCounts } = await context.$occ.api.getProducts(searchParams);
     return {
       products,
-      total
+      total,
+      facets,
+      categories: categories.value,
+      categoryCounts
     };
   }
 };
 
-export const useFacet = useFacetFactory<SearchParams>(factoryParams);
+export const useFacet = useFacetFactory<AgnosticFacetSearchParams>(factoryParams);

--- a/packages/composables/src/useProduct/index.ts
+++ b/packages/composables/src/useProduct/index.ts
@@ -4,6 +4,7 @@ import {
   ProductsSearchParams,
   UseProductFactoryParams
 } from '@vue-storefront/core';
+import { ProductsQueryType } from '@vue-storefront/orc-vsf-api';
 import type { Product } from '@vue-storefront/orc-vsf-api';
 import type { UseProductSearchParams as SearchParams } from '../types';
 
@@ -11,12 +12,21 @@ const params: UseProductFactoryParams<Product, SearchParams> = {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   productsSearch: async (
     context: Context,
-    params: ProductsSearchParams
+    params: ProductsSearchParams & {
+      queryType: ProductsQueryType;
+    }
   ): Promise<Product> => {
     const app: any = context.$occ.config.app;
-
     const locale: any = app.i18n.locale;
-    return await context.$occ.api.getProduct({ ...params, locale });
+    const { queryType } = params;
+
+    switch (queryType) {
+      case ProductsQueryType.Detail:
+        return await context.$occ.api.getProduct({ ...params, locale });
+      case ProductsQueryType.List:
+      default:
+        return await context.$occ.api.getProducts({ ...params, locale });
+    }
   }
 };
 

--- a/packages/theme/composables/useUiHelpers/index.ts
+++ b/packages/theme/composables/useUiHelpers/index.ts
@@ -1,5 +1,6 @@
 
 import { getCurrentInstance } from '@nuxtjs/composition-api';
+import { AgnosticCategoryTree } from '@vue-storefront/core';
 
 const getContext = () => {
   const vm = getCurrentInstance();
@@ -37,16 +38,14 @@ const useUiHelpers = () => {
     return {
       categorySlug,
       page: parseInt(query.page as string, 10) || 1,
+      sort: query.sort || 'latest',
+      term: query.term,
+      filters: getFiltersDataFromUrl(context, true),
       itemsPerPage: parseInt(query.itemsPerPage as string, 10) || 12
     } as any;
   };
 
-  // eslint-disable-next-line
-  const getCatLink = (category): string => {
-    console.warn('[VSF] please implement useUiHelpers.getCatLink.');
-
-    return '/';
-  };
+  const getCatLink = (category: AgnosticCategoryTree): string => `/c/${category.slug}`;
 
   // eslint-disable-next-line
   const changeSorting = (sort) => {

--- a/packages/theme/middleware.config.js
+++ b/packages/theme/middleware.config.js
@@ -10,7 +10,9 @@ module.exports = {
         scope: process.env.OVERTURE_SCOPE_NAME,
         inventoryLocationIds: process.env.OVERTURE_INVENTORY_LOCATION_IDS,
         searchConfig: {
-          defaultItemsPerPage: 12
+          defaultItemsPerPage: 12,
+          availableFacets: ['CategoryLevel1_Facet','CategoryLevel2_Facet','Brand'],
+          categoryCountFacets: ['CategoryLevel1', 'CategoryLevel2', 'CategoryLevel3']
         }
       },
     },

--- a/packages/theme/pages/Category.vue
+++ b/packages/theme/pages/Category.vue
@@ -1,0 +1,469 @@
+<template>
+  <div id="category">
+    <SfBreadcrumbs
+      class="breadcrumbs desktop-only"
+      :breadcrumbs="breadcrumbs"
+    >
+      <template #link="{ breadcrumb }">
+        <nuxt-link
+          :data-testid="breadcrumb.text"
+          :to="breadcrumb.link ? localePath(breadcrumb.link) : ''"
+          class="sf-link disable-active-link sf-breadcrumbs__breadcrumb"
+        >
+          {{ breadcrumb.text }}
+        </nuxt-link>
+      </template>
+    </SfBreadcrumbs>
+    <div class="navbar section">
+      <div class="navbar__aside desktop-only">
+        <LazyHydrate never>
+          <SfHeading
+            :level="3"
+            :title="$t('Categories')"
+            class="navbar__title" />
+        </LazyHydrate>
+      </div>
+      <CategoryPageHeader :pagination="pagination"/>
+    </div>
+
+    <div class="main section">
+      <div class="sidebar desktop-only">
+        <LazyHydrate when-idle>
+          <SfLoader
+          :class="{ 'loading--categories': loading }"
+          :loading="loading">
+            <SfAccordion
+              v-e2e="'categories-accordion'"
+              :open="activeCategory"
+              :show-chevron="true"
+            >
+              <SfAccordionItem
+                v-for="(cat, i) in categoryTree && categoryTree.items"
+                :key="i"
+                :header="cat.label"
+              >
+                <template>
+                  <SfList class="list">
+                    <SfListItem class="list__item">
+                      <SfMenuItem
+                        :count="cat.count || ''"
+                        :label="cat.label"
+                      >
+                        <template #label>
+                          <nuxt-link
+                            :to="localePath(th.getCatLink(cat))"
+                            :class="cat.isCurrent ? 'sidebar--cat-selected' : ''"
+                          >
+                            All
+                          </nuxt-link>
+                        </template>
+                      </SfMenuItem>
+                    </SfListItem>
+                    <SfListItem
+                      class="list__item"
+                      v-for="(subCat, j) in cat.items"
+                      :key="j"
+                    >
+                      <SfMenuItem
+                        :count="subCat.count || ''"
+                        :label="subCat.label"
+                      >
+                        <template #label="{ label }">
+                          <nuxt-link
+                            :to="localePath(th.getCatLink(subCat))"
+                            :class="subCat.isCurrent ? 'sidebar--cat-selected' : ''"
+                          >
+                            {{ label }}
+                          </nuxt-link>
+                        </template>
+                      </SfMenuItem>
+                    </SfListItem>
+                  </SfList>
+                </template>
+              </SfAccordionItem>
+            </SfAccordion>
+          </SfLoader>
+        </LazyHydrate>
+      </div>
+      <SfLoader :class="{ loading }" :loading="loading">
+        <div class="products" v-if="!loading">
+          <transition-group
+            v-if="isCategoryGridView"
+            appear
+            name="products__slide"
+            tag="div"
+            class="products__grid"
+          >
+            <SfProductCard
+              v-e2e="'category-product-card'"
+              v-for="(product, i) in products"
+              :key="productGetters.getSlug(product)"
+              :style="{ '--index': i }"
+              :title="productGetters.getName(product)"
+              :image="addBasePath(productGetters.getCoverImage(product))"
+              :regular-price="$n(productGetters.getPrice(product).regular, 'currency')"
+              :special-price="productGetters.getPrice(product).special && $n(productGetters.getPrice(product).special, 'currency')"
+              :max-rating="5"
+              :score-rating="productGetters.getAverageRating(product)"
+              :show-add-to-cart-button="true"
+              :is-in-wishlist="isInWishlist({ product })"
+              :is-added-to-cart="isInCart({ product })"
+              :link="localePath(`/p/${productGetters.getId(product)}/${productGetters.getSlug(product)}`)"
+              class="products__product-card"
+              @click:wishlist="!isInWishlist({ product }) ? addItemToWishlist({ product }) : removeProductFromWishlist(product)"
+              @click:add-to-cart="addToCart({ product, quantity: 1 })"
+            />
+          </transition-group>
+          <transition-group
+            v-else
+            appear
+            name="products__slide"
+            tag="div"
+            class="products__list"
+          >
+            <SfProductCardHorizontal
+              v-e2e="'category-product-card'"
+              v-for="(product, i) in products"
+              class="products__product-card-horizontal"
+              :key="productGetters.getSlug(product)"
+              :style="{ '--index': i }"
+              :title="productGetters.getName(product)"
+              :description="productGetters.getDescription(product)"
+              :image="addBasePath(productGetters.getCoverImage(product))"
+              :regular-price="$n(productGetters.getPrice(product).regular, 'currency')"
+              :special-price="productGetters.getPrice(product).special && $n(productGetters.getPrice(product).special, 'currency')"
+              :max-rating="5"
+              :score-rating="3"
+              :qty="1"
+              :is-in-wishlist="isInWishlist({ product })"
+              :link="localePath(`/p/${productGetters.getId(product)}/${productGetters.getSlug(product)}`)"
+              @input="productsQuantity[product._id] = $event"
+              @click:wishlist="!isInWishlist({ product }) ? addItemToWishlist({ product }) : removeProductFromWishlist(product)"
+              @click:add-to-cart="addToCart({ product, quantity: Number(productsQuantity[product._id]) })"
+            >
+              <template #configuration>
+                <SfProperty
+                  class="desktop-only"
+                  name="Size"
+                  value="XS"
+                  style="margin: 0 0 1rem 0;"
+                />
+                <SfProperty class="desktop-only" name="Color" value="white" />
+              </template>
+              <template #actions>
+                <SfButton
+                  class="sf-button--text desktop-only"
+                  style="margin: 0 0 1rem auto; display: block;"
+                  @click="() => {}"
+                >
+                  {{ $t('Save for later') }}
+                </SfButton>
+              </template>
+            </SfProductCardHorizontal>
+          </transition-group>
+
+          <LazyHydrate on-interaction>
+            <SfPagination
+              v-if="!loading"
+              class="products__pagination desktop-only"
+              v-show="pagination.totalPages > 1"
+              :current="pagination.currentPage"
+              :total="pagination.totalPages"
+              :visible="5"
+            />
+          </LazyHydrate>
+
+          <div
+            v-show="pagination.totalPages > 1"
+            class="products__show-on-page"
+          >
+            <span class="products__show-on-page__label">{{ $t('Show on page') }}</span>
+            <LazyHydrate on-interaction>
+              <SfSelect
+                :value="pagination && pagination.itemsPerPage ? pagination.itemsPerPage.toString() : ''"
+                class="products__items-per-page"
+                @input="th.changeItemsPerPage"
+              >
+                <SfSelectOption
+                  v-for="option in pagination.pageOptions"
+                  :key="option"
+                  :value="option"
+                  class="products__items-per-page__option"
+                >
+                  {{ option }}
+                </SfSelectOption>
+              </SfSelect>
+            </LazyHydrate>
+          </div>
+        </div>
+      </SfLoader>
+    </div>
+  </div>
+</template>
+
+<script>
+import {
+  SfSidebar,
+  SfButton,
+  SfList,
+  SfIcon,
+  SfHeading,
+  SfMenuItem,
+  SfFilter,
+  SfProductCard,
+  SfProductCardHorizontal,
+  SfPagination,
+  SfAccordion,
+  SfSelect,
+  SfBreadcrumbs,
+  SfLoader,
+  SfColor,
+  SfProperty
+} from '@storefront-ui/vue';
+import { computed, ref } from '@nuxtjs/composition-api';
+import { useCart, useWishlist, productGetters, useFacet, facetGetters, wishlistGetters } from '@vue-storefront/orc-vsf';
+import { useUiHelpers, useUiState } from '~/composables';
+import { onSSR } from '@vue-storefront/core';
+import LazyHydrate from 'vue-lazy-hydration';
+import CategoryPageHeader from '~/components/CategoryPageHeader';
+import { addBasePath } from '@vue-storefront/core';
+
+// TODO(addToCart qty, horizontal): https://github.com/vuestorefront/storefront-ui/issues/1606
+export default {
+  transition: 'fade',
+  setup(props, context) {
+    const th = useUiHelpers();
+    const uiState = useUiState();
+    const { addItem: addItemToCart, isInCart } = useCart();
+    const { result, search, loading, error } = useFacet();
+    const { addItem: addItemToWishlist, isInWishlist, removeItem: removeItemFromWishlist, wishlist } = useWishlist();
+
+    const productsQuantity = ref({});
+    const products = computed(() => facetGetters.getProducts(result.value));
+    const categoryTree = computed(() => facetGetters.getCategoryTree(result.value));
+    const breadcrumbs = computed(() => facetGetters.getBreadcrumbs(result.value));
+    const pagination = computed(() => facetGetters.getPagination(result.value));
+    const activeCategory = computed(() => {
+      const items = categoryTree.value.items;
+
+      if (!items || !items.length) {
+        return '';
+      }
+
+      const category = items.find(({ isCurrent, items }) => isCurrent || items.find(({ isCurrent }) => isCurrent));
+
+      return category?.label || items[0].label;
+    });
+
+    const removeProductFromWishlist = (productItem) => {
+      const productsInWhishlist = computed(() => wishlistGetters.getItems(wishlist.value));
+      const product = productsInWhishlist.value.find(wishlistProduct => wishlistProduct.variant.sku === productItem.sku);
+      removeItemFromWishlist({ product });
+    };
+
+    const addToCart = ({ product, quantity }) => {
+      const { id, sku } = product;
+      addItemToCart({
+        product: { id, sku },
+        quantity
+      });
+    };
+
+    onSSR(async () => {
+      await search({...th.getFacetsFromURL(), withCategoryCounts: true});
+      if (error?.value?.search) context.root.$nuxt.error({ statusCode: 404 });
+    });
+
+    return {
+      ...uiState,
+      th,
+      products,
+      categoryTree,
+      loading,
+      productGetters,
+      pagination,
+      activeCategory,
+      breadcrumbs,
+      addItemToWishlist,
+      removeProductFromWishlist,
+      isInWishlist,
+      addToCart,
+      isInCart,
+      productsQuantity,
+      addBasePath
+    };
+  },
+  components: {
+    CategoryPageHeader,
+    SfButton,
+    SfSidebar,
+    SfIcon,
+    SfList,
+    SfFilter,
+    SfProductCard,
+    SfProductCardHorizontal,
+    SfPagination,
+    SfMenuItem,
+    SfAccordion,
+    SfSelect,
+    SfBreadcrumbs,
+    SfLoader,
+    SfColor,
+    SfHeading,
+    SfProperty,
+    LazyHydrate
+  }
+};
+</script>
+
+<style lang="scss" scoped>
+#category {
+  box-sizing: border-box;
+  @include for-desktop {
+    max-width: 1240px;
+    margin: 0 auto;
+  }
+}
+.main {
+  &.section {
+    padding: var(--spacer-xs);
+    @include for-desktop {
+      padding: 0;
+    }
+  }
+}
+.breadcrumbs {
+  margin: var(--spacer-base) auto var(--spacer-lg);
+}
+.navbar {
+  position: relative;
+  display: flex;
+  border: 1px solid var(--c-light);
+  border-width: 0 0 1px 0;
+  @include for-desktop {
+    border-width: 1px 0 1px 0;
+  }
+  &.section {
+    padding: var(--spacer-sm);
+    @include for-desktop {
+      padding: 0;
+    }
+  }
+  &__aside {
+    display: flex;
+    align-items: center;
+    padding: var(--spacer-sm) 0;
+    flex: 0 0 15%;
+    padding: var(--spacer-sm) var(--spacer-sm);
+    border: 1px solid var(--c-light);
+    border-width: 0 1px 0 0;
+  }
+  &__title {
+    --heading-title-font-weight: var(--font-weight--semibold);
+    --heading-title-font-size: var(--font-size--xl);
+  }
+}
+.main {
+  display: flex;
+}
+.list {
+  --menu-item-font-size: var(--font-size--sm);
+  &__item {
+    &:not(:last-of-type) {
+      --list-item-margin: 0 0 var(--spacer-sm) 0;
+    }
+    .nuxt-link-exact-active {
+      text-decoration: underline;
+    }
+  }
+}
+.products {
+  box-sizing: border-box;
+  flex: 1;
+  margin: 0;
+  &__grid {
+    justify-content: center;
+    @include for-desktop {
+      justify-content: flex-start;
+    }
+  }
+  &__grid,
+  &__list {
+    display: flex;
+    flex-wrap: wrap;
+  }
+  &__product-card {
+    --product-card-title-margin: var(--spacer-base) 0 0 0;
+    --product-card-title-font-weight: var(--font-weight--medium);
+    --product-card-title-margin: var(--spacer-xs) 0 0 0;
+    flex: 1 1 50%;
+    @include for-desktop {
+      --product-card-title-font-weight: var(--font-weight--normal);
+      --product-card-add-button-bottom: var(--spacer-base);
+      --product-card-title-margin: var(--spacer-sm) 0 0 0;
+    }
+  }
+  &__product-card-horizontal {
+    flex: 0 0 100%;
+    @include for-mobile {
+      ::v-deep .sf-image {
+        --image-width: 5.3125rem;
+        --image-height: 7.0625rem;
+      }
+    }
+  }
+  &__slide-enter {
+    opacity: 0;
+    transform: scale(0.5);
+  }
+  &__slide-enter-active {
+    transition: all 0.2s ease;
+    transition-delay: calc(0.1s * var(--index));
+  }
+  @include for-desktop {
+    &__grid {
+      margin: var(--spacer-sm) 0 0 var(--spacer-sm);
+    }
+    &__pagination {
+      display: flex;
+      justify-content: flex-start;
+      margin: var(--spacer-xl) 0 0 0;
+    }
+    &__product-card-horizontal {
+      margin: var(--spacer-lg) 0;
+    }
+    &__product-card {
+      flex: 1 1 25%;
+    }
+    &__list {
+      margin: 0 0 0 var(--spacer-sm);
+    }
+  }
+  &__show-on-page {
+    display: flex;
+    justify-content: flex-end;
+    align-items: baseline;
+    &__label {
+      font-family: var(--font-family--secondary);
+      font-size: var(--font-size--sm);
+    }
+  }
+}
+.sidebar {
+  flex: 0 0 15%;
+  padding: var(--spacer-sm);
+  border: 1px solid var(--c-light);
+  border-width: 0 1px 0 0;
+}
+.loading {
+  margin: var(--spacer-3xl) auto;
+  @include for-desktop {
+    margin-top: 6.25rem;
+  }
+  &--categories {
+    @include for-desktop {
+      margin-top: 3.75rem;
+    }
+  }
+}
+</style>


### PR DESCRIPTION
Implement useFacet composable be used on category pages as side navigation and breadcrumbs

## Description
Implement useFacet composable and add docs

## Related Issue
[AB#60255](https://dev.azure.com/orckestra001/da965986-c85b-43be-9915-219568b000e5/_workitems/edit/60255)

## Motivation and Context
Ability to have category tree navigation and breadcrumbs on category pages

## How Has This Been Tested?
On Category pages as side navigation and category breadcribms

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/6649972/166912510-3608d77e-81f3-493f-a134-d8fdef133b15.png)

## Types of changes
- [ ] add api call to get category facets counts
- [ ] implement getCategoryTree for useFacet composable
- [ ] implement getBreadcrumbs for useFacet composable
- [ ] add docs use-facets and use-product

