### PR TITLE
feat: implement facets filters for category pages

### DIFF
--- a/docs/guide/use-facet.md
+++ b/docs/guide/use-facet.md
@@ -6,19 +6,34 @@
 ## API
 ```typescript
 interface UseFacet<any> {
-  result: ComputedProperty<FacetSearchResult<Facet>>;
+  result: ComputedProperty<FacetSearchResult<SearchResults>>;
   loading: ComputedProperty<boolean>;
   search: (params?: AgnosticFacetSearchParams) => Promise<void>;
   error: ComputedProperty<UseFacetErrors>;
 }
 
-export interface Facet {
+export interface SearchResults {
     total: any,
     products: any,
-    facets: any,
+    facets: Facet[],
     categories?: Category[],
     categoryCounts: any
 }
+
+export declare type Facet = {
+    facetType: any;
+    title: string;
+    fieldName: string;
+    values: FacetValue[];
+};
+
+export declare type FacetValue = {
+    minimumValue?: any;
+    maximumValue?: any;
+    value: string;
+    displayName: string;
+    count: number;
+};
 
 export interface Category {
   id: string
@@ -44,13 +59,12 @@ Reactive object containing the error message, if search failed for any reason.
 ## Getters
 ````typescript
 interface FacetsGetters<Facet> {
-  getAll: (data: FacetSearchResult<Facet>, criteria?: CRITERIA) => AgnosticFacet[];
-  getGrouped: (data: FacetSearchResult<Facet>, criteria?: CRITERIA) => AgnosticGroupedFacet[];
-  getCategoryTree: (data: FacetSearchResult<Facet>, root?: string = 'Root', level = 3) => AgnosticCategoryTree;
-  getSortOptions: (data: FacetSearchResult<Facet>) => AgnosticSort;
-  getProducts: (data: FacetSearchResult<Facet>) => RESULTS;
-  getPagination: (data: FacetSearchResult<Facet>) => AgnosticPagination;
-  getBreadcrumbs: (data: FacetSearchResult<Facet>) => AgnosticBreadcrumb[];
+  getGrouped: (data: FacetSearchResult<SearchResults>, criteria?: string[]) => AgnosticGroupedFacet[];
+  getCategoryTree: (data: FacetSearchResult<SearchResults>, root?: string = 'Root', level = 3) => AgnosticCategoryTree;
+  getSortOptions: (data: FacetSearchResult<SearchResults>) => AgnosticSort;
+  getProducts: (data: FacetSearchResult<SearchResults>) => RESULTS;
+  getPagination: (data: FacetSearchResult<SearchResults>) => AgnosticPagination;
+  getBreadcrumbs: (data: FacetSearchResult<SearchResults>) => AgnosticBreadcrumb[];
 }
 ````
 ## Example
@@ -66,6 +80,7 @@ export default {
     const categoryTree = computed(() => facetGetters.getCategoryTree(result.value));
     const breadcrumbs = computed(() => facetGetters.getBreadcrumbs(result.value));
     const pagination = computed(() => facetGetters.getPagination(result.value));
+    const facets = computed(() => facetGetters.getGrouped(result.value, ['Brand','SeasonWear']));
 
     onSSR(async () => {
        await search({...th.getFacetsFromURL(), withCategoryCounts: true});
@@ -76,6 +91,7 @@ export default {
       categoryTree,
       breadcrumbs,
       pagination,
+      facets,
       loading
     }
   }

--- a/docs/guide/use-facet.md
+++ b/docs/guide/use-facet.md
@@ -25,6 +25,9 @@ export declare type Facet = {
     title: string;
     fieldName: string;
     values: FacetValue[];
+    gapSize?: string;
+    startValue?: string;
+    endValue?: string;
 };
 
 export declare type FacetValue = {
@@ -59,7 +62,7 @@ Reactive object containing the error message, if search failed for any reason.
 ## Getters
 ````typescript
 interface FacetsGetters<Facet> {
-  getGrouped: (data: FacetSearchResult<SearchResults>, criteria?: string[]) => AgnosticGroupedFacet[];
+  getGrouped: (data: FacetSearchResult<SearchResults>, criteria?: string[]) => (AgnosticGroupedFacet & {type: string});
   getCategoryTree: (data: FacetSearchResult<SearchResults>, root?: string = 'Root', level = 3) => AgnosticCategoryTree;
   getSortOptions: (data: FacetSearchResult<SearchResults>) => AgnosticSort;
   getProducts: (data: FacetSearchResult<SearchResults>) => RESULTS;

--- a/packages/api-client/src/api/getProducts/index.ts
+++ b/packages/api-client/src/api/getProducts/index.ts
@@ -7,9 +7,7 @@ export default async function getProducts(
 ) {
   const { catId, categorySlug, withCategoryCounts, categories, filters, page, itemsPerPage, locale, sort } = params;
   const { api, scope, inventoryLocationIds, searchConfig, cdnDamProviderConfig } = context.config;
-  const facetPredicates = buildFacetPredicates(categories, categorySlug, filters, searchConfig);
-
-  let url = null;
+   let url = null;
 
   const setCoverImages = (products: any) => {
     const { serverUrl, imageFolderName } = cdnDamProviderConfig;
@@ -24,16 +22,21 @@ export default async function getProducts(
     });
   };
 
-  const sortOptions = sort.split('-');
-  const sortObj = {
-    direction: sortOptions && sortOptions.length === 2 && sortOptions[1] === 'desc' ? '1' : '0',
-    propertyName: sortOptions && sortOptions.length > 0 ? sortOptions[0] : 'score'
-  };
+  const getSort = (sort) => {
+    if (!sort) return;
+    const sortOptions = sort.split('-');
+    return {
+      direction: sortOptions && sortOptions.length === 2 && sortOptions[1] === 'desc' ? '1' : '0',
+      propertyName: sortOptions && sortOptions.length > 0 ? sortOptions[0] : 'score'
+    };
+  }
 
+  
   if (catId) {
     console.log('TODO: Related');
     return [];
   } else if (categorySlug) {
+    const facetPredicates = buildFacetPredicates(categories, categorySlug, filters, searchConfig);
     let categoryCounts = [];
     url = new URL(`/api/search/${scope}/${locale}/availableProducts/byCategory/${categorySlug}`, api.url);
     const maximumItems = itemsPerPage ?? searchConfig.defaultItemsPerPage;
@@ -46,7 +49,7 @@ export default async function getProducts(
       query: {
         maximumItems: maximumItems,
         startingIndex: (page - 1) * maximumItems,
-        sortings: [sortObj]
+        sortings: [getSort(sort)]
       }
     });
 
@@ -77,7 +80,7 @@ export default async function getProducts(
         distinctResults: true,
         maximumItems: searchConfig.defaultItemsPerPage,
         startingIndex: 0,
-        sortings: [sortObj]
+        sortings: [getSort(sort)]
       }
     });
 

--- a/packages/api-client/src/api/getProducts/index.ts
+++ b/packages/api-client/src/api/getProducts/index.ts
@@ -7,7 +7,7 @@ export default async function getProducts(
 ) {
   const { catId, categorySlug, withCategoryCounts, categories, filters, page, itemsPerPage, locale, sort } = params;
   const { api, scope, inventoryLocationIds, searchConfig, cdnDamProviderConfig } = context.config;
-   let url = null;
+  let url = null;
 
   const setCoverImages = (products: any) => {
     const { serverUrl, imageFolderName } = cdnDamProviderConfig;
@@ -29,9 +29,8 @@ export default async function getProducts(
       direction: sortOptions && sortOptions.length === 2 && sortOptions[1] === 'desc' ? '1' : '0',
       propertyName: sortOptions && sortOptions.length > 0 ? sortOptions[0] : 'score'
     };
-  }
+  };
 
-  
   if (catId) {
     console.log('TODO: Related');
     return [];

--- a/packages/api-client/src/api/getProducts/index.ts
+++ b/packages/api-client/src/api/getProducts/index.ts
@@ -1,11 +1,15 @@
+
+import { buildFacetPredicates } from '../../helpers/buildFacetPredicates';
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 export default async function getProducts(
   context,
   params
 ) {
-  const { catId, categorySlug, withCategoryCounts, facetPredicates, page, itemsPerPage, locale } = params;
+  const { catId, categorySlug, withCategoryCounts, categories, filters, page, itemsPerPage, locale } = params;
   const { api, scope, inventoryLocationIds, searchConfig, cdnDamProviderConfig } = context.config;
+  const facetPredicates = buildFacetPredicates(categories, categorySlug, filters, searchConfig);
+
   let url = null;
 
   const setCoverImages = (products: any) => {
@@ -33,7 +37,7 @@ export default async function getProducts(
       categoryName: categorySlug,
       includeFacets: true,
       facetPredicates,
-      facets: searchConfig.availableFacets,
+      facets: searchConfig.availableFacets.map(f => f.name),
       query: {
         maximumItems: maximumItems,
         startingIndex: (page - 1) * maximumItems,

--- a/packages/api-client/src/helpers/buildFacetPredicates.ts
+++ b/packages/api-client/src/helpers/buildFacetPredicates.ts
@@ -1,7 +1,7 @@
 import type { Category } from '@vue-storefront/orc-vsf-api';
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-export const buildFacetPredicates = (categories: any, rootCategory: string, filters?: any): any => {
+export const buildFacetPredicates = (categories: any, rootCategory: string, filters?: any, config?: any): any => {
   if (!Array.isArray(categories)) return [];
   const root: Category = categories.find(c => c.id === rootCategory);
   if (!root) return [];
@@ -26,16 +26,28 @@ export const buildFacetPredicates = (categories: any, rootCategory: string, filt
   }));
 
   if (filters) {
-    Object.keys(filters).map(filterKey => {
+    Object.keys(filters).forEach(filterKey => {
       const options = filters[filterKey];
+      const facetConfig = config.availableFacets.find(f => f.name === filterKey);
+      if(!facetConfig) return;
       if (options && options.length) {
-        facetPredicates.push({
-          facetType: 1,
+        let predicate: any = {
+          facetType: facetConfig.type,
           fieldName: filterKey,
           values: filters[filterKey],
           operatorType: 0,
           excludeFilterForFacetsCount: true
-        })
+        };
+
+        //Range
+        if (facetConfig.type === 2) {
+          let values = options[0].split('_');
+          predicate.values = null,
+          predicate.minimumValue = parseFloat(values[0]);
+          predicate.maximumValue = parseFloat(values[1]);
+        }
+
+        facetPredicates.push(predicate);
       }
     })
   };

--- a/packages/api-client/src/helpers/buildFacetPredicates.ts
+++ b/packages/api-client/src/helpers/buildFacetPredicates.ts
@@ -29,9 +29,9 @@ export const buildFacetPredicates = (categories: any, rootCategory: string, filt
     Object.keys(filters).forEach(filterKey => {
       const options = filters[filterKey];
       const facetConfig = config.availableFacets.find(f => f.name === filterKey);
-      if(!facetConfig) return;
+      if (!facetConfig) return;
       if (options && options.length) {
-        let predicate: any = {
+        const predicate: any = {
           facetType: facetConfig.type,
           fieldName: filterKey,
           values: filters[filterKey],
@@ -39,9 +39,9 @@ export const buildFacetPredicates = (categories: any, rootCategory: string, filt
           excludeFilterForFacetsCount: true
         };
 
-        //Range
+        // Range
         if (facetConfig.type === 2) {
-          let values = options[0].split('_');
+          const values = options[0].split('_');
           predicate.values = null,
           predicate.minimumValue = parseFloat(values[0]);
           predicate.maximumValue = parseFloat(values[1]);
@@ -49,8 +49,8 @@ export const buildFacetPredicates = (categories: any, rootCategory: string, filt
 
         facetPredicates.push(predicate);
       }
-    })
-  };
+    });
+  }
 
   return facetPredicates;
 };

--- a/packages/api-client/src/types.ts
+++ b/packages/api-client/src/types.ts
@@ -24,12 +24,12 @@ export type Category = {
 
 export type Coupon = TODO;
 
-export type SearchResults = {
-    total: any,
-    products: any,
-    facets: Facet[],
-    categories?: Category[],
-    categoryCounts?: any
+export type FacetValue = {
+    minimumValue?: any,
+    maximumValue?: any,
+    value: string,
+    displayName: string,
+    count: number
 };
 
 export type Facet = {
@@ -42,12 +42,12 @@ export type Facet = {
     endValue?: string
 };
 
-export type FacetValue = {
-    minimumValue?: any,
-    maximumValue?: any,
-    value: string,
-    displayName: string,
-    count: number
+export type SearchResults = {
+    total: any,
+    products: any,
+    facets: Facet[],
+    categories?: Category[],
+    categoryCounts?: any
 };
 
 export const enum FacetType

--- a/packages/api-client/src/types.ts
+++ b/packages/api-client/src/types.ts
@@ -36,7 +36,10 @@ export type Facet = {
     facetType: any,
     title: string,
     fieldName: string,
-    values: FacetValue[]
+    values: FacetValue[],
+    gapSize?: string,
+    startValue?: string,
+    endValue?: string
 };
 
 export type FacetValue = {
@@ -46,6 +49,13 @@ export type FacetValue = {
     displayName: string,
     count: number
 };
+
+export const enum FacetType
+{
+    SingleSelect = 0,
+    MultiSelect = 1,
+    Range = 2
+}
 
 export type FacetSearchCriteria = TODO;
 

--- a/packages/api-client/src/types.ts
+++ b/packages/api-client/src/types.ts
@@ -24,12 +24,27 @@ export type Category = {
 
 export type Coupon = TODO;
 
-export type Facet = {
+export type SearchResults = {
     total: any,
     products: any,
-    facets: any,
+    facets: Facet[],
     categories?: Category[],
     categoryCounts?: any
+};
+
+export type Facet = {
+    facetType: any,
+    title: string,
+    fieldName: string,
+    values: FacetValue[]
+};
+
+export type FacetValue = {
+    minimumValue?: any,
+    maximumValue?: any,
+    value: string,
+    displayName: string,
+    count: number
 };
 
 export type FacetSearchCriteria = TODO;

--- a/packages/composables/src/getters/facetGetters.ts
+++ b/packages/composables/src/getters/facetGetters.ts
@@ -18,8 +18,8 @@ function getAll(params: FacetSearchResult<SearchResults>, criteria?: FacetSearch
 }
 
 function getGrouped(params: FacetSearchResult<SearchResults>, criteria?: string[]): (AgnosticGroupedFacet & {type: string})[] {
-  var facets = params.data?.facets;
-  var filters = params.input?.filters;
+  let facets = params.data?.facets;
+  const filters = params.input?.filters;
   if (!facets) return;
 
   const getMetadata = (facet: Facet) => {
@@ -27,20 +27,20 @@ function getGrouped(params: FacetSearchResult<SearchResults>, criteria?: string[
       startValue: facet.startValue,
       endValue: facet.endValue,
       gapSize: facet.gapSize
-    }
-  }
+    };
+  };
 
   if (criteria) {
     facets = facets.filter(f => criteria.includes(f.fieldName));
   }
 
   return facets.map(facet => {
-    let selectedList = filters && filters[facet.fieldName] ? filters[facet.fieldName] : [];
+    const selectedList = filters && filters[facet.fieldName] ? filters[facet.fieldName] : [];
     return {
       id: facet.fieldName,
       label: facet.title,
       type: facet.facetType,
-      options: facet.values.map((v, index) =>
+      options: facet.values.map((v) =>
         ({
           id: v.value,
           value: v.value,

--- a/packages/composables/src/getters/facetGetters.ts
+++ b/packages/composables/src/getters/facetGetters.ts
@@ -8,29 +8,50 @@ import {
   AgnosticBreadcrumb,
   AgnosticFacet
 } from '@vue-storefront/core';
-import type { Facet, FacetSearchCriteria } from '@vue-storefront/orc-vsf-api';
+import type { SearchResults, FacetSearchCriteria } from '@vue-storefront/orc-vsf-api';
 import { buildCategoryTree } from '../helpers/buildCategoryTree';
 import { setProductCounts } from '../helpers/categoriesUtils';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-function getAll(params: FacetSearchResult<Facet>, criteria?: FacetSearchCriteria): AgnosticFacet[] {
+function getAll(params: FacetSearchResult<SearchResults>, criteria?: FacetSearchCriteria): AgnosticFacet[] {
   return [];
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-function getGrouped(params: FacetSearchResult<Facet>, criteria?: FacetSearchCriteria): AgnosticGroupedFacet[] {
-  return [];
+function getGrouped(params: FacetSearchResult<SearchResults>, criteria?: string[]): AgnosticGroupedFacet[] {
+  var facets = params.data?.facets;
+  var filters = params.input?.filters;
+  if (!facets) return;
+
+  if (criteria) {
+    facets = facets.filter(f => criteria.includes(f.fieldName));
+  }
+
+  return facets.map(facet => {
+    let selectedList = filters && filters[facet.fieldName] ? filters[facet.fieldName] : [];
+    return {
+      id: facet.fieldName,
+      label: facet.title,
+      options: facet.values.map((v, index) =>
+        ({
+          id: v.value,
+          value: v.value,
+          type: facet.facetType,
+          count: v.count,
+          selected: selectedList.includes(v.value)
+        }))
+    };
+  }).filter(i => i && i.options && i.options.length);
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-function getSortOptions(params: FacetSearchResult<Facet>): AgnosticSort {
+function getSortOptions(params: FacetSearchResult<SearchResults>): AgnosticSort {
   return {
     options: [],
     selected: ''
   };
 }
 
-function getCategoryTree(params: FacetSearchResult<Facet>, root = 'Root', level = 3): AgnosticCategoryTree {
+function getCategoryTree(params: FacetSearchResult<SearchResults>, root = 'Root', level = 3): AgnosticCategoryTree {
   if (!params.data) return;
 
   const { categoryCounts } = params.data;
@@ -44,12 +65,12 @@ function getCategoryTree(params: FacetSearchResult<Facet>, root = 'Root', level 
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-function getProducts(params: FacetSearchResult<Facet>): any {
+function getProducts(params: FacetSearchResult<SearchResults>): any {
   return params.data?.products;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-function getPagination(params: FacetSearchResult<Facet>): AgnosticPagination {
+function getPagination(params: FacetSearchResult<SearchResults>): AgnosticPagination {
   const { data, input } = params;
   if (!data) return;
   return {
@@ -62,7 +83,7 @@ function getPagination(params: FacetSearchResult<Facet>): AgnosticPagination {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-function getBreadcrumbs(params: FacetSearchResult<Facet>, includeHome = true): AgnosticBreadcrumb[] {
+function getBreadcrumbs(params: FacetSearchResult<SearchResults>, includeHome = true): AgnosticBreadcrumb[] {
   const breadcrumbs = [];
   if (!params.data) {
     return breadcrumbs;
@@ -88,7 +109,7 @@ function getBreadcrumbs(params: FacetSearchResult<Facet>, includeHome = true): A
   return breadcrumbs.reverse();
 }
 
-export const facetGetters: FacetsGetters<Facet, FacetSearchCriteria> = {
+export const facetGetters: FacetsGetters<SearchResults, FacetSearchCriteria> = {
   getSortOptions,
   getGrouped,
   getAll,

--- a/packages/composables/src/getters/productGetters.ts
+++ b/packages/composables/src/getters/productGetters.ts
@@ -13,7 +13,11 @@ function getName(product: Product): string {
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getSlug(product: Product): string {
-  return product?.propertyBag?.DisplayName;
+  return product?.sku;
+}
+
+function getBrand(product: Product): string {
+  return product?.propertyBag?.Brand;
 }
 
 function getPrice(product: Product): AgnosticPrice {
@@ -97,6 +101,7 @@ export const productGetters: ProductGetters<Product, ProductFilter> = {
   getName,
   getSlug,
   getPrice,
+  getBrand,
   getGallery,
   getCoverImage,
   getFiltered,

--- a/packages/composables/src/helpers/buildFacetPredicates.ts
+++ b/packages/composables/src/helpers/buildFacetPredicates.ts
@@ -1,7 +1,7 @@
 import type { Category } from '@vue-storefront/orc-vsf-api';
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-export const buildFacetPredicates = (categories: any, rootCategory: string): any => {
+export const buildFacetPredicates = (categories: any, rootCategory: string, filters?: any): any => {
   if (!Array.isArray(categories)) return [];
   const root: Category = categories.find(c => c.id === rootCategory);
   if (!root) return [];
@@ -24,6 +24,21 @@ export const buildFacetPredicates = (categories: any, rootCategory: string): any
     operatorType: 0,
     excludeFilterForFacetsCount: true
   }));
+
+  if (filters) {
+    Object.keys(filters).map(filterKey => {
+      const options = filters[filterKey];
+      if (options && options.length) {
+        facetPredicates.push({
+          facetType: 1,
+          fieldName: filterKey,
+          values: filters[filterKey],
+          operatorType: 0,
+          excludeFilterForFacetsCount: true
+        })
+      }
+    })
+  };
 
   return facetPredicates;
 };

--- a/packages/composables/src/useFacet/index.ts
+++ b/packages/composables/src/useFacet/index.ts
@@ -14,8 +14,8 @@ const factoryParams = {
     const { categories } = useCategory('categories');
     const { ...searchParams } = params.input;
     searchParams.locale = app.i18n.locale;
-    const { categorySlug } = searchParams;
-    searchParams.facetPredicates = buildFacetPredicates(categories.value, categorySlug);
+    const { categorySlug, filters } = searchParams;
+    searchParams.facetPredicates = buildFacetPredicates(categories.value, categorySlug, filters);
     const { products, total, facets, categoryCounts } = await context.$occ.api.getProducts(searchParams);
     return {
       products,

--- a/packages/composables/src/useFacet/index.ts
+++ b/packages/composables/src/useFacet/index.ts
@@ -5,17 +5,16 @@ import {
 } from '@vue-storefront/core';
 import { AgnosticFacetSearchParams } from '@vue-storefront/core';
 import { useCategory } from '../useCategory';
-import { buildFacetPredicates } from '../helpers/buildFacetPredicates';
 
 const factoryParams = {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   search: async (context: Context, params: FacetSearchResult<AgnosticFacetSearchParams>) => {
     const app: any = context.$occ.config.app;
+  
     const { categories } = useCategory('categories');
     const { ...searchParams } = params.input;
     searchParams.locale = app.i18n.locale;
-    const { categorySlug, filters } = searchParams;
-    searchParams.facetPredicates = buildFacetPredicates(categories.value, categorySlug, filters);
+    searchParams.categories = categories.value;
     const { products, total, facets, categoryCounts } = await context.$occ.api.getProducts(searchParams);
     return {
       products,

--- a/packages/composables/src/useFacet/index.ts
+++ b/packages/composables/src/useFacet/index.ts
@@ -10,7 +10,7 @@ const factoryParams = {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   search: async (context: Context, params: FacetSearchResult<AgnosticFacetSearchParams>) => {
     const app: any = context.$occ.config.app;
-  
+
     const { categories } = useCategory('categories');
     const { ...searchParams } = params.input;
     searchParams.locale = app.i18n.locale;

--- a/packages/theme/components/FiltersSidebar.vue
+++ b/packages/theme/components/FiltersSidebar.vue
@@ -1,0 +1,241 @@
+<template>
+  <div id="filters">
+    <SfSidebar
+      :visible="isFilterSidebarOpen"
+      title="Filters"
+      class="sidebar-filters"
+      @close="toggleFilterSidebar"
+    >
+      <div class="filters desktop-only">
+        <div v-for="(facet, i) in facets" :key="i">
+          <SfHeading
+            :level="4"
+            :title="facet.label"
+            class="filters__title sf-heading--left"
+            :key="`filter-title-${facet.id}`"
+          />
+          <div
+            v-if="isFacetColor(facet)"
+            class="filters__colors"
+            :key="`${facet.id}-colors`"
+          >
+            <SfColor
+              v-for="option in facet.options"
+              :key="`${facet.id}-${option.value}`"
+              :color="option.value"
+              :selected="isFilterSelected(facet, option)"
+              class="filters__color"
+              @click="() => selectFilter(facet, option)"
+            />
+          </div>
+          <div v-else>
+            <SfFilter
+              v-for="option in facet.options"
+              :key="`${facet.id}-${option.value}`"
+              :label="option.id + `${option.count ? ` (${option.count})` : ''}`"
+              :selected="isFilterSelected(facet, option)"
+              class="filters__item"
+              @change="() => selectFilter(facet, option)"
+            />
+          </div>
+        </div>
+      </div>
+      <SfAccordion class="filters smartphone-only">
+        <div v-for="(facet, i) in facets" :key="i">
+          <SfAccordionItem
+            :key="`filter-title-${facet.id}`"
+            :header="facet.label"
+            class="filters__accordion-item"
+          >
+            <SfFilter
+              v-for="option in facet.options"
+              :key="`${facet.id}-${option.id}`"
+              :label="option.id"
+              :selected="isFilterSelected(facet, option)"
+              class="filters__item"
+              @change="() => selectFilter(facet, option)"
+            />
+          </SfAccordionItem>
+        </div>
+      </SfAccordion>
+      <template #content-bottom>
+        <div class="filters__buttons">
+          <SfButton
+            class="sf-button--full-width"
+            @click="applyFilters"
+          >
+            {{ $t('Done') }}
+          </SfButton
+          >
+          <SfButton
+            class="sf-button--full-width filters__button-clear"
+            @click="clearFilters"
+          >
+            {{ $t('Clear all') }}
+          </SfButton
+          >
+        </div>
+      </template>
+    </SfSidebar>
+  </div>
+</template>
+
+<script>
+import {
+  SfSidebar,
+  SfButton,
+  SfHeading,
+  SfFilter,
+  SfAccordion,
+  SfColor
+} from '@storefront-ui/vue';
+
+import { ref, computed, onMounted } from '@nuxtjs/composition-api';
+import { useFacet, facetGetters } from '@vue-storefront/orc-vsf';
+import { useUiHelpers, useUiState } from '~/composables';
+import Vue from 'vue';
+
+export default {
+  name: 'FiltersSidebar',
+  components: {
+    SfButton,
+    SfSidebar,
+    SfFilter,
+    SfAccordion,
+    SfColor,
+    SfHeading
+  },
+  setup(props, context) {
+    const { changeFilters, isFacetColor } = useUiHelpers();
+    const { toggleFilterSidebar, isFilterSidebarOpen } = useUiState();
+    const { result } = useFacet();
+
+    const facets = computed(() => facetGetters.getGrouped(result.value, ['Brand','SeasonWear','ShirtType','ShoeType','HeelsHeight']));
+    const selectedFilters = ref({});
+
+    const setSelectedFilters = () => {
+      if (!facets.value.length || Object.keys(selectedFilters.value).length) return;
+      selectedFilters.value = facets.value.reduce((prev, curr) => ({
+        ...prev,
+        [curr.id]: curr.options
+          .filter(o => o.selected)
+          .map(o => o.id)
+      }), {});
+    };
+
+    const isFilterSelected = (facet, option) => (selectedFilters.value[facet.id] || []).includes(option.id);
+
+    const selectFilter = (facet, option) => {
+      if (!selectedFilters.value[facet.id]) {
+        Vue.set(selectedFilters.value, facet.id, []);
+      }
+
+      if (selectedFilters.value[facet.id].find(f => f === option.id)) {
+        selectedFilters.value[facet.id] = selectedFilters.value[facet.id].filter(f => f !== option.id);
+        return;
+      }
+
+      selectedFilters.value[facet.id].push(option.id);
+    };
+
+    const clearFilters = () => {
+      toggleFilterSidebar();
+      selectedFilters.value = {};
+      changeFilters(selectedFilters.value);
+    };
+
+    const applyFilters = () => {
+      toggleFilterSidebar();
+      changeFilters(selectedFilters.value);
+    };
+
+    onMounted(() => {
+      context.root.$scrollTo(context.root.$el, 2000);
+      setSelectedFilters();
+    });
+
+    return {
+      facets,
+      isFacetColor,
+      selectFilter,
+      isFilterSelected,
+      isFilterSidebarOpen,
+      toggleFilterSidebar,
+      clearFilters,
+      applyFilters
+    };
+  }
+};
+</script>
+
+<style lang="scss" scoped>
+.sidebar-filters {
+  --overlay-z-index: 3;
+  --sidebar-title-display: none;
+  --sidebar-top-padding: 0;
+  @include for-desktop {
+    --sidebar-content-padding: 0 var(--spacer-xl);
+    --sidebar-bottom-padding: 0 var(--spacer-xl);
+  }
+}
+::v-deep .sf-sidebar__aside {
+  --sidebar-z-index: 3;
+}
+.filters {
+  &__title {
+    --heading-title-font-size: var(--font-size--xl);
+    margin: var(--spacer-xl) 0 var(--spacer-base) 0;
+    &:first-child {
+      margin: calc(var(--spacer-xl) + var(--spacer-base)) 0 var(--spacer-xs) 0;
+    }
+  }
+  &__colors {
+    display: flex;
+  }
+  &__color {
+    margin: var(--spacer-xs) var(--spacer-xs) var(--spacer-xs) 0;
+  }
+  &__chosen {
+    color: var(--c-text-muted);
+    font-weight: var(--font-weight--normal);
+    font-family: var(--font-family--secondary);
+    position: absolute;
+    right: var(--spacer-xl);
+  }
+  &__item {
+    --radio-container-padding: 0 var(--spacer-sm) 0 var(--spacer-xl);
+    --radio-background: transparent;
+    --filter-label-color: var(--c-secondary-variant);
+    --filter-count-color: var(--c-secondary-variant);
+    --checkbox-padding: 0 var(--spacer-sm) 0 var(--spacer-xl);
+    padding: var(--spacer-sm) 0;
+    border-bottom: 1px solid var(--c-light);
+    &:last-child {
+      border-bottom: 0;
+    }
+    @include for-desktop {
+      --checkbox-padding: 0;
+      margin: var(--spacer-sm) 0;
+      border: 0;
+      padding: 0;
+    }
+  }
+  &__accordion-item {
+    --accordion-item-content-padding: 0;
+    position: relative;
+    left: 50%;
+    right: 50%;
+    margin-left: -50vw;
+    margin-right: -50vw;
+    width: 100vw;
+  }
+  &__buttons {
+    margin: var(--spacer-sm) 0;
+  }
+  &__button-clear {
+    --button-background: var(--c-light);
+    --button-color: var(--c-dark-variant);
+    margin: var(--spacer-xs) 0 0 0;
+  }
+}
+</style>

--- a/packages/theme/components/FiltersSidebar.vue
+++ b/packages/theme/components/FiltersSidebar.vue
@@ -111,7 +111,7 @@ export default {
     const { toggleFilterSidebar, isFilterSidebarOpen } = useUiState();
     const { result } = useFacet();
 
-    const facets = computed(() => facetGetters.getGrouped(result.value, ['Brand','SeasonWear','ShirtType','ShoeType','HeelsHeight','CurrentPrice']));
+    const facets = computed(() => facetGetters.getGrouped(result.value, ['Brand', 'SeasonWear', 'ShirtType', 'ShoeType', 'HeelsHeight', 'CurrentPrice']));
     const selectedFilters = ref({});
 
     const setSelectedFilters = () => {
@@ -131,8 +131,8 @@ export default {
         Vue.set(selectedFilters.value, facet.id, []);
       }
 
-      if(isFacetRange(facet)) {
-        selectedFilters.value[facet.id]  = [option.join('_')];
+      if (isFacetRange(facet)) {
+        selectedFilters.value[facet.id] = [option.join('_')];
         return;
       }
 
@@ -145,24 +145,24 @@ export default {
     };
 
     const getRangeConfig = facet => {
-      if(!facet.options || !facet.options.length) return {};
-      var filters = result.value.input?.filters;
-      var selectedList = filters && filters[facet.id] ? filters[facet.id] : [];
+      if (!facet.options || !facet.options.length) return {};
+      const filters = result.value.input?.filters;
+      const selectedList = filters && filters[facet.id] ? filters[facet.id] : [];
 
       const { metadata } = facet.options[0];
       const {startValue, endValue, gapSize} = metadata;
       const start = selectedList.length ? selectedList[0].split('_').map(i => parseFloat(i)) : [parseFloat(startValue), parseFloat(endValue)];
-      return {"start": start,
-      "range":{"min":parseFloat(startValue),"max":parseFloat(endValue)},
-      "step":parseFloat(gapSize),
-      "connect":true,
-      "direction":"ltr",
-      "orientation":"horizontal",
-      "behaviour":
-      "tap-drag",
-      "tooltips":true,
-      "keyboardSupport":true};
-    }
+      return {start: start,
+        range: {min: parseFloat(startValue), max: parseFloat(endValue)},
+        step: parseFloat(gapSize),
+        connect: true,
+        direction: 'ltr',
+        orientation: 'horizontal',
+        behaviour:
+      'tap-drag',
+        tooltips: true,
+        keyboardSupport: true};
+    };
 
     const clearFilters = () => {
       toggleFilterSidebar();

--- a/packages/theme/composables/useUiHelpers/index.ts
+++ b/packages/theme/composables/useUiHelpers/index.ts
@@ -1,6 +1,7 @@
 
 import { getCurrentInstance } from '@nuxtjs/composition-api';
 import { AgnosticCategoryTree } from '@vue-storefront/core';
+import { useRoute, useRouter } from '@nuxtjs/composition-api';
 
 const getContext = () => {
   const vm = getCurrentInstance();
@@ -28,7 +29,7 @@ const getFiltersDataFromUrl = (context, onlyFilters) => {
 
 // eslint-disable-next-line
 const useUiHelpers = () => {
-
+  const router = useRouter();
   const context = getContext();
 
   const getFacetsFromURL = () => {
@@ -56,7 +57,12 @@ const useUiHelpers = () => {
 
   // eslint-disable-next-line
   const changeFilters = (filters) => {
-    console.warn('[VSF] please implement useUiHelpers.changeFilters.');
+    router.push({
+      query: {
+        ...getFiltersDataFromUrl(context, false),
+        ...filters,
+      },
+    });
   };
 
   // eslint-disable-next-line

--- a/packages/theme/composables/useUiHelpers/index.ts
+++ b/packages/theme/composables/useUiHelpers/index.ts
@@ -87,6 +87,11 @@ const useUiHelpers = () => {
     return false;
   };
 
+  const isFacetRange = (facet): boolean => {
+    const type = facet.type;
+    return type === 'Range' || type === '2';
+  };
+
   // eslint-disable-next-line
   const isFacetCheckbox = (facet): boolean => {
     console.warn('[VSF] please implement useUiHelpers.isFacetCheckbox.');
@@ -106,6 +111,7 @@ const useUiHelpers = () => {
     changeItemsPerPage,
     setTermForUrl,
     isFacetColor,
+    isFacetRange,
     isFacetCheckbox,
     getSearchTermFromUrl
   };

--- a/packages/theme/composables/useUiHelpers/index.ts
+++ b/packages/theme/composables/useUiHelpers/index.ts
@@ -1,7 +1,7 @@
 
 import { getCurrentInstance } from '@nuxtjs/composition-api';
 import { AgnosticCategoryTree } from '@vue-storefront/core';
-import { useRoute, useRouter } from '@nuxtjs/composition-api';
+import { useRouter } from '@nuxtjs/composition-api';
 
 const getContext = () => {
   const vm = getCurrentInstance();
@@ -60,8 +60,8 @@ const useUiHelpers = () => {
     router.push({
       query: {
         ...getFiltersDataFromUrl(context, false),
-        ...filters,
-      },
+        ...filters
+      }
     });
   };
 

--- a/packages/theme/middleware.config.js
+++ b/packages/theme/middleware.config.js
@@ -11,7 +11,13 @@ module.exports = {
         inventoryLocationIds: process.env.OVERTURE_INVENTORY_LOCATION_IDS,
         searchConfig: {
           defaultItemsPerPage: 12,
-          availableFacets: ['Brand','SeasonWear','ShirtType','ShoeType','HeelsHeight'],
+          availableFacets: [
+            { name: 'Brand', type: 1 },
+            { name: 'SeasonWear', type: 1 },
+            { name: 'ShirtType', type: 1 },
+            { name: 'ShoeType', type: 1 },
+            { name: 'HeelsHeight', type: 1 },
+            { name: 'CurrentPrice', type: 2 }],
           categoryCountFacets: ['CategoryLevel1', 'CategoryLevel2', 'CategoryLevel3']
         },
         cdnDamProviderConfig: {

--- a/packages/theme/middleware.config.js
+++ b/packages/theme/middleware.config.js
@@ -11,7 +11,7 @@ module.exports = {
         inventoryLocationIds: process.env.OVERTURE_INVENTORY_LOCATION_IDS,
         searchConfig: {
           defaultItemsPerPage: 12,
-          availableFacets: ['CategoryLevel1_Facet','CategoryLevel2_Facet','Brand'],
+          availableFacets: ['Brand','SeasonWear','ShirtType','ShoeType','HeelsHeight'],
           categoryCountFacets: ['CategoryLevel1', 'CategoryLevel2', 'CategoryLevel3']
         }
       },

--- a/packages/theme/pages/Category.vue
+++ b/packages/theme/pages/Category.vue
@@ -144,11 +144,10 @@
               <template #configuration>
                 <SfProperty
                   class="desktop-only"
-                  name="Size"
-                  value="XS"
+                  name="Brand"
+                  :value="productGetters.getBrand(product)"
                   style="margin: 0 0 1rem 0;"
                 />
-                <SfProperty class="desktop-only" name="Color" value="white" />
               </template>
               <template #actions>
                 <SfButton

--- a/packages/theme/pages/Category.vue
+++ b/packages/theme/pages/Category.vue
@@ -243,7 +243,7 @@ export default {
     const breadcrumbs = computed(() => facetGetters.getBreadcrumbs(result.value));
     const pagination = computed(() => facetGetters.getPagination(result.value));
     const activeCategory = computed(() => {
-      const items = categoryTree.value.items;
+    const items = categoryTree.value?.items;
 
       if (!items || !items.length) {
         return '';

--- a/packages/theme/pages/Category.vue
+++ b/packages/theme/pages/Category.vue
@@ -243,7 +243,7 @@ export default {
     const breadcrumbs = computed(() => facetGetters.getBreadcrumbs(result.value));
     const pagination = computed(() => facetGetters.getPagination(result.value));
     const activeCategory = computed(() => {
-    const items = categoryTree.value?.items;
+      const items = categoryTree.value?.items;
 
       if (!items || !items.length) {
         return '';


### PR DESCRIPTION
Implement facet filters for category pages

## Description
- implement faterGetters.getGrouped() 
- add configuration for avalable facets
- add FiltersSidebar.vue to sources with example how to use and have Price Range filter

## Related Issue
[AB#60272](https://dev.azure.com/orckestra001/da965986-c85b-43be-9915-219568b000e5/_workitems/edit/60272)

## Motivation and Context
Ability to filter list pages by factes like Brand, Size, Price

## How Has This Been Tested?
It was tested in default theme, in FiltersSidebar. Use StoreFront Range component (https://docs.storefrontui.io/?path=/docs/components-molecules-range--common) for Price Range facet.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/6649972/168045776-323a7966-729f-4f9e-81be-776814687163.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
