### PR TITLE
feat: checkout order summary

### DIFF
--- a/docs/guide/use-cart.md
+++ b/docs/guide/use-cart.md
@@ -38,9 +38,83 @@ export declare type CartItem = {
     recurringOrderFrequencyName: string;
     coverImage?: string;
 };
+export declare type Tax = {
+    code: string;
+    displayName: any;
+    id: string;
+    isShippingFeeTax: boolean;
+    isShippingTax: boolean;
+    lineItemIds: any;
+    percentage: number;
+    taxAmount: number;
+    taxCategoryId: string;
+    taxForShipmentId: string;
+    taxTotal: number;
+};
+export declare type FulfillmentMethod = {
+    id: string;
+    propertyBag: any;
+    carrierName: string;
+    carrierOptionDisplayName: any;
+    carrierServiceLevel: string;
+    cost: number;
+    displayName: any;
+    expectedDeliveryDate: string;
+    fulfillmentMethodType: string;
+    shipmentId: string;
+    shippingProviderId: string;
+    taxCategory: string;
+};
+export declare type ShipmentAdditionalFee = {
+    id: string;
+    amount: number;
+    description: string;
+    displayName: any;
+    name: string;
+    taxable: boolean;
+    taxCategory: string;
+};
+export declare const enum RewardLevel {
+    LineItem = 0,
+    Shipment = 1,
+    FulfillmentMethod = 2,
+    None = 3
+}
+export declare const enum RewardType {
+    Discount = 0,
+    External = 1,
+    Gift = 2
+}
+export declare type Reward = {
+    id: string;
+    amount: number;
+    propertyBag: any;
+    campaignId: string;
+    campaignName: string;
+    description: string;
+    level: RewardLevel;
+    promotionId: string;
+    promotionName: string;
+    promotionVersion: number;
+    relatedObjectId: string;
+    rewardType: RewardType;
+};
 export declare type Shipment = {
+    id: string;
+    additionalFeeAmount?: number;
+    additionalFees?: ShipmentAdditionalFee[];
+    address?: UserAddress;
     lineItems: CartItem[];
     fulfillmentLocationId: string;
+    fulfillmentMethod: FulfillmentMethod;
+    status: string;
+    taxes?: Tax[];
+    taxProviderId?: string;
+    taxTotal?: number;
+    total: number;
+    trackingNumber?: string;
+    propertyBag?: any;
+    rewards?: Reward[];
 };
 export declare type Cart = {
     messages?: any;
@@ -81,22 +155,32 @@ Checks if a product is currently in the cart.
 Reactive object containing information about loading state of the cart.
 
 ## cartGetters
-
-- `getTotals` - Return an object cart totals
-    - `total` (float) - The value of cart total
-    - `subtotal` (float) - The value of cart sub total.
-- `getShippingPrice` - To retrieve shipping price. 
-- `getItems` - Return list of cart items.
-- `getItemName` - Accept one parameter `CartItem` and return the name of product.
-- `getItemImage` - Accept one parameter `CartItem` and return the image source URL of product.
-- `getItemPrice` - Accept one parameter `CartItem` and return the price of product.
-- `getItemQty` - Accept one parameter `CartItem` and return the quantity of product.
-- `getItemAttributes` - Accept two parameter, `CartItem` and `filterByAttributeName` (Optional). 
-- `getItemSku` - Accept one parameter `CartItem` and return the sku of product.
-- `getItemStatus` - Accept one parameter `CartItem` and return the status of product, like InStock, OutOfStock.
-- `getTotalItems` - To get the total numbers of cart items
-- `getCoupons` - TODO
-- `getDiscounts` - TODO
+````typescript
+export interface CartGetters<Cart, CartItem> {
+    getItems: (cart: Cart) => CartItem[];
+    getItemName: (cartItem: CartItem) => string;
+    getItemImage: (cartItem: CartItem) => string;
+    getItemPrice: (cartItem: CartItem) => AgnosticPrice;
+    getItemQty: (cartItem: CartItem) => number;
+    getItemAttributes: (cartItem: CartItem, filters?: Array<string>) => Record<string, AgnosticAttribute | string>;
+    getItemSku: (cartItem: CartItem) => string;
+    getTotals: (cart: Cart) => AgnosticTotals;
+    getShippingPrice: (cart: Cart) => number;
+    getTotalItems: (cart: CACartRT) => number;
+    getFormattedPrice: (price: number) => string;
+    getCoupons: (cart: Cart) => AgnosticCoupon[]; // TODO
+    getDiscounts: (cart: Cart) => AgnosticDiscount[]; // TODO or use getRewards
+    getRewards(cart: Cart, levels?: RewardLevel[]) =>  Reward[];
+    getTaxes(cart: Cart) => Tax[];
+    getActiveShipment(cart: Cart) =>  Shipment;
+    getActiveShipments(cart: Cart) =>  Shipment[];
+    isShippingTaxable(shipment: Shipment) => boolean;
+    isShippingEstimated(shipment: Shipment) => boolean;
+    isActiveShippingEstimated(cart: Cart) => boolean;
+    getTaxableAdditionalFees(cart: Cart) => ShipmentAdditionalFee[];
+    getNotTaxableAdditionalFees(cart: Cart) => ShipmentAdditionalFee[];
+}
+````
 
 ## Examples
 Cart composable is designed for supporting a single cart and access it everywhere with ease.

--- a/docs/guide/use-cart.md
+++ b/docs/guide/use-cart.md
@@ -170,6 +170,7 @@ export interface CartGetters<Cart, CartItem> {
     getFormattedPrice: (price: number) => string;
     getCoupons: (cart: Cart) => AgnosticCoupon[]; // TODO
     getDiscounts: (cart: Cart) => AgnosticDiscount[]; // TODO or use getRewards
+    getItemsDiscountsAmount(cart: Cart) => number;
     getRewards(cart: Cart, levels?: RewardLevel[]) =>  Reward[];
     getTaxes(cart: Cart) => Tax[];
     getActiveShipment(cart: Cart) =>  Shipment;

--- a/packages/api-client/src/types.ts
+++ b/packages/api-client/src/types.ts
@@ -1,3 +1,5 @@
+import { UseUserAddress } from '@vue-storefront/core';
+
 export type TODO = unknown;
 
 export type Setttings = TODO;
@@ -19,6 +21,73 @@ export type CartItemSummary = {
     allowSelectionWithoutScan: boolean
 }
 
+export type Tax = {
+    code: string,
+    displayName: any,
+    id: string,
+    isShippingFeeTax: boolean,
+    isShippingTax: boolean,
+    lineItemIds: any,
+    percentage: number,
+    taxAmount: number,
+    taxCategoryId: string,
+    taxForShipmentId: string,
+    taxTotal: number
+}
+
+export type FulfillmentMethod = {
+    id: string,
+    propertyBag: any,
+    carrierName: string,
+    carrierOptionDisplayName: any,
+    carrierServiceLevel: string,
+    cost: number,
+    displayName: any,
+    expectedDeliveryDate: string,
+    fulfillmentMethodType: string,
+    shipmentId: string,
+    shippingProviderId: string,
+    taxCategory: string
+}
+
+export type ShipmentAdditionalFee = {
+    id: string,
+    amount: number,
+    description: string,
+    displayName: any,
+    name: string,
+    taxable: boolean,
+    taxCategory: string
+}
+
+export const enum RewardLevel {
+    LineItem = 0,
+    Shipment = 1,
+    FulfillmentMethod = 2,
+    None = 3
+}
+
+export const enum RewardType {
+    Discount = 0,
+    External = 1,
+    Gift = 2
+}
+
+export type Reward = {
+    id: string,
+    amount: number,
+    propertyBag: any,
+    campaignId: string,
+    campaignName: string,
+    description: string,
+    level: RewardLevel,
+    promotionId: string,
+    promotionName: string,
+    promotionVersion: number,
+    relatedObjectId: string,
+    rewardType: RewardType
+}
+
 export type CartItem = {
     id: string,
     productSummary: CartItemSummary,
@@ -29,6 +98,7 @@ export type CartItem = {
     regularPrice: number,
     defaultPrice: number,
     placedPrice: number,
+    discountAmount: number,
     total: number,
     status: string,
     sku: string,
@@ -39,12 +109,27 @@ export type CartItem = {
     variantId: string,
     recurringOrderProgramName: string,
     recurringOrderFrequencyName: string,
-    coverImage?:string
+    coverImage?:string,
+    isGiftItem: boolean,
+    rewards: Reward[],
 }
 
 export type Shipment = {
-    lineItems: CartItem [],
-    fulfillmentLocationId: string
+    id: string,
+    additionalFeeAmount?: number,
+    additionalFees?: ShipmentAdditionalFee[],
+    address?: UserAddress,
+    lineItems: CartItem[],
+    fulfillmentLocationId: string,
+    fulfillmentMethod: FulfillmentMethod,
+    status: string,
+    taxes?: Tax[],
+    taxProviderId?: string,
+    taxTotal?: number,
+    total: number,
+    trackingNumber?: string,
+    propertyBag?: any,
+    rewards?: Reward[]
 }
 
 export type Cart = {
@@ -58,12 +143,17 @@ export type Cart = {
     taxTotal: number,
     merchandiseTotal: number,
     total: number,
+    fulfillmentCost: number,
+    fulfillmentCostWithoutDiscount: number,
+    fulfillmentLevelDiscountTotal: number,
     scopeId: string,
     status: string,
     lineItemsTotalWithoutDiscount: number,
     lineItemLevelDiscount: number,
     lineItemsTotal: number,
-    itemCount: number
+    itemCount: number,
+    discountTotal: number,
+    subTotalDiscount: number
 };
 
 export type Category = {

--- a/packages/api-client/src/types.ts
+++ b/packages/api-client/src/types.ts
@@ -1,5 +1,3 @@
-import { UseUserAddress } from '@vue-storefront/core';
-
 export type TODO = unknown;
 
 export type Setttings = TODO;
@@ -7,6 +5,30 @@ export type Setttings = TODO;
 export type Endpoints = TODO;
 
 export type BillingAddress = TODO;
+
+export type UserAddress = {
+    addressName: string,
+    city: string,
+    countryCode: string,
+    email: string,
+    firstName: string,
+    id: string,
+    isPreferredBilling: boolean,
+    isPreferredShipping: boolean,
+    lastModified: string,
+    lastModifiedBy: string,
+    lastName: string,
+    latitude: number,
+    line1: string,
+    line2: string,
+    longitude: number,
+    notes: string,
+    phoneExtension: string,
+    phoneNumber: string,
+    postalCode: string,
+    propertyBag: object
+    regionCode: string
+};
 
 export type CartItemSummary = {
     propertyBag: any,
@@ -354,30 +376,6 @@ export type UserBillingAddress = TODO;
 export type UserBillingAddressItem = TODO;
 
 export type UserBillingAddressSearchCriteria = TODO;
-
-export type UserAddress = {
-    addressName: string,
-    city: string,
-    countryCode: string,
-    email: string,
-    firstName: string,
-    id: string,
-    isPreferredBilling: boolean,
-    isPreferredShipping: boolean,
-    lastModified: string,
-    lastModifiedBy: string,
-    lastName: string,
-    latitude: number,
-    line1: string,
-    line2: string,
-    longitude: number,
-    notes: string,
-    phoneExtension: string,
-    phoneNumber: string,
-    postalCode: string,
-    propertyBag: object
-    regionCode: string
-};
 
 export type UserShippingAddressSearchCriteria = TODO;
 

--- a/packages/composables/src/getters/cartGetters.ts
+++ b/packages/composables/src/getters/cartGetters.ts
@@ -100,7 +100,7 @@ function getActiveShipments(cart: Cart): Shipment[] {
 }
 
 function isShippingTaxable(shipment: Shipment): boolean {
-  return shipment.taxes?.some(t => t.taxForShipmentId === shipment.fulfillmentMethod?.shipmentId && t.taxTotal > 0);
+  return shipment?.taxes?.some(t => t.taxForShipmentId === shipment.fulfillmentMethod?.shipmentId && t.taxTotal > 0);
 }
 
 function isShippingEstimated(shipment: Shipment): boolean {
@@ -119,15 +119,15 @@ function isActiveShippingTaxable(cart: Cart): boolean {
 
 function getTaxes(cart: Cart): Tax[] {
   const shipment = getActiveShipment(cart);
-  return shipment.taxes?.filter(t => t.taxTotal > 0);
+  return shipment?.taxes?.filter(t => t.taxTotal > 0);
 }
 
 function getRewards(cart: Cart, levels?: RewardLevel[]): Reward[] {
   const shipment = getActiveShipment(cart);
-  const rewards = shipment.rewards;
+  const rewards = shipment?.rewards;
 
   if (levels) {
-    return rewards.filter(r => levels.includes(r.level));
+    return rewards?.filter(r => levels.includes(r.level));
   }
 
   return rewards;

--- a/packages/composables/src/getters/cartGetters.ts
+++ b/packages/composables/src/getters/cartGetters.ts
@@ -10,7 +10,7 @@ import type { Cart, CartItem, Shipment, Tax, Reward, RewardLevel, ShipmentAdditi
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getItems(cart: Cart): CartItem[] {
-  const shipment = cart?.shipments[0];
+  const shipment = getActiveShipment(cart);
   return shipment?.lineItems;
 }
 
@@ -163,6 +163,12 @@ function getDiscounts(cart: Cart): AgnosticDiscount[] {
   return [];
 }
 
+function getItemsDiscountsAmount(cart: Cart): number {
+  const items = getItems(cart);
+  if (!items) return 0;
+  return items.reduce((a, el) => ((el.defaultPrice - el.currentPrice) * el.quantity) + a, 0);
+}
+
 function getLink(item: CartItem): string {
   if (!item) return;
   const variantId = item.variantId;
@@ -187,6 +193,7 @@ export const cartGetters: CartGetters<Cart, CartItem> = {
   getTotalItems,
   getCoupons,
   getDiscounts,
+  getItemsDiscountsAmount,
   getLink,
   getActiveShipment,
   getActiveShipments,

--- a/packages/composables/src/getters/cartGetters.ts
+++ b/packages/composables/src/getters/cartGetters.ts
@@ -6,7 +6,7 @@ import {
   AgnosticDiscount,
   AgnosticAttribute
 } from '@vue-storefront/core';
-import type { Cart, CartItem, Shipment, Tax, Reward, RewardLevel } from '@vue-storefront/orc-vsf-api';
+import type { Cart, CartItem, Shipment, Tax, Reward, RewardLevel, ShipmentAdditionalFee } from '@vue-storefront/orc-vsf-api';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getItems(cart: Cart): CartItem[] {
@@ -133,6 +133,16 @@ function getRewards(cart: Cart, levels?: RewardLevel[]): Reward[] {
   return rewards;
 }
 
+function getTaxableAdditionalFees(cart: Cart): ShipmentAdditionalFee[] {
+  const shipment = getActiveShipment(cart);
+  return shipment?.additionalFees?.filter(f => f.taxable);
+}
+
+function getNotTaxableAdditionalFees(cart: Cart): ShipmentAdditionalFee[] {
+  const shipment = getActiveShipment(cart);
+  return shipment?.additionalFees?.filter(f => !f.taxable);
+}
+
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 function getTotalItems(cart: Cart): number {
   return cart?.itemCount;
@@ -185,5 +195,7 @@ export const cartGetters: CartGetters<Cart, CartItem> = {
   isActiveShippingEstimated,
   isActiveShippingTaxable,
   getTaxes,
-  getRewards
+  getRewards,
+  getTaxableAdditionalFees,
+  getNotTaxableAdditionalFees
 };

--- a/packages/composables/src/getters/cartGetters.ts
+++ b/packages/composables/src/getters/cartGetters.ts
@@ -38,7 +38,7 @@ function getItemTotals(item: CartItem): AgnosticTotals {
     subtotal: item?.total,
     special: undefined,
     totalWithoutDiscount: item?.totalWithoutDiscount
-  }
+  };
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -92,15 +92,15 @@ function getShippingPrice(cart: Cart): number {
 }
 
 function getActiveShipment(cart: Cart): Shipment {
-  return cart?.shipments?.find(s => s.status !== 'Canceled')
+  return cart?.shipments?.find(s => s.status !== 'Canceled');
 }
 
 function getActiveShipments(cart: Cart): Shipment[] {
-  return cart?.shipments?.filter(s => s.status !== 'Canceled')
+  return cart?.shipments?.filter(s => s.status !== 'Canceled');
 }
 
 function isShippingTaxable(shipment: Shipment): boolean {
-  return shipment.taxes?.some(t => t.taxForShipmentId === shipment.fulfillmentMethod?.shipmentId && t.taxTotal > 0)
+  return shipment.taxes?.some(t => t.taxForShipmentId === shipment.fulfillmentMethod?.shipmentId && t.taxTotal > 0);
 }
 
 function isShippingEstimated(shipment: Shipment): boolean {
@@ -179,6 +179,7 @@ export const cartGetters: CartGetters<Cart, CartItem> = {
   getDiscounts,
   getLink,
   getActiveShipment,
+  getActiveShipments,
   isShippingTaxable,
   isShippingEstimated,
   isActiveShippingEstimated,

--- a/packages/theme/components/CartSidebar.vue
+++ b/packages/theme/components/CartSidebar.vue
@@ -28,12 +28,24 @@
                 :regular-price="cartGetters.getItemPrice(product).regular && $n(cartGetters.getItemPrice(product).regular, 'currency')"
                 :special-price="cartGetters.getItemPrice(product).special && $n(cartGetters.getItemPrice(product).special, 'currency')"
                 :stock="99"
+                :qty="cartGetters.getItemQty(product)"
                 :link="localePath(cartGetters.getLink(product))"
                 @click:remove="removeItem({ product: { id: product.id } })"
                 :class="`collected-product status-${cartGetters.getItemStatus(product)}`"
               >
+                <template #price>
+                <SfPrice
+                  :regular="cartGetters.getItemPrice(product).regular && $n(cartGetters.getItemPrice(product).regular, 'currency')"
+                  :special="cartGetters.getItemPrice(product).special && $n(cartGetters.getItemPrice(product).special, 'currency')"
+                />
+                <SfProperty
+                      name="Total"
+                      :value="$n(cartGetters.getItemTotals(product).total, 'currency')"
+                />
+      </template>
                 <template #configuration>
                   <div class="collected-product__properties">
+                  
                     <SfProperty
                       v-for="(attribute, key) in cartGetters.getItemAttributes(product, ['Colour', 'RetailSize'])"
                       :key="key"
@@ -90,11 +102,12 @@
             >
               <template #value>
                 <SfPrice
-                  :regular="$n(totals.subtotal, 'currency')"
-                  :special="(totals.special !== totals.subtotal) ? $n(totals.special, 'currency') : 0"
+                  :regular="totals.subtotaldiscount > 0 ? $n(totals.subtotal + totals.subtotaldiscount, 'currency') : $n(totals.subtotal, 'currency')"
+                  :special="(totals.subtotaldiscount > 0) ? $n(totals.subtotal, 'currency') : 0"
                 />
               </template>
             </SfProperty>
+            <CartSaving class="my-cart__saving"/>
             <nuxt-link :to="localePath({ name: 'shipping' })">
               <SfButton
                 class="sf-button--full-width color-secondary"
@@ -128,6 +141,7 @@ import {
   SfImage,
   SfQuantitySelector
 } from '@storefront-ui/vue';
+import  CartSaving from './Checkout/CartSaving'
 import { computed, useRouter} from '@nuxtjs/composition-api';
 import { useCart, cartGetters, useMetadata, metadataGetters } from '@vue-storefront/orc-vsf';
 import { useUiState } from '~/composables';
@@ -145,7 +159,8 @@ export default {
     SfPrice,
     SfCollectedProduct,
     SfImage,
-    SfQuantitySelector
+    SfQuantitySelector,
+    CartSaving
   },
   setup() {
     const router = useRouter();
@@ -156,7 +171,6 @@ export default {
     const products = computed(() => cartGetters.getItems(cart.value));
     const totals = computed(() => cartGetters.getTotals(cart.value));
     const totalItems = computed(() => cartGetters.getTotalItems(cart.value));
-
     const updateQuantity = debounce(async ({ product, quantity }) => {
       await updateItemQty({ product, quantity });
     }, 500);
@@ -206,7 +220,24 @@ export default {
     --price-font-weight: var(--font-weight--medium);
     margin: 0 0 var(--spacer-base) 0;
   }
+  &__saving {
+    margin-bottom: var(--spacer-base);
+  }
 }
+
+.rewards-title {
+  --heading-title-color: var(--c-warning);
+  padding-bottom: var(--spacer-xs);
+}
+
+.property-reward {
+  color: var(--c-warning);
+  &:last-child {
+    padding-bottom: var(--spacer-xs);
+  }
+
+}
+
 .empty-cart {
   --heading-description-margin: 0 0 var(--spacer-xl) 0;
   --heading-title-margin: 0 0 var(--spacer-xl) 0;

--- a/packages/theme/components/CartSidebar.vue
+++ b/packages/theme/components/CartSidebar.vue
@@ -45,7 +45,7 @@
       </template>
                 <template #configuration>
                   <div class="collected-product__properties">
-                  
+
                     <SfProperty
                       v-for="(attribute, key) in cartGetters.getItemAttributes(product, ['Colour', 'RetailSize'])"
                       :key="key"
@@ -141,7 +141,7 @@ import {
   SfImage,
   SfQuantitySelector
 } from '@storefront-ui/vue';
-import  CartSaving from './Checkout/CartSaving'
+import CartSaving from './Checkout/CartSaving';
 import { computed, useRouter} from '@nuxtjs/composition-api';
 import { useCart, cartGetters, useMetadata, metadataGetters } from '@vue-storefront/orc-vsf';
 import { useUiState } from '~/composables';

--- a/packages/theme/components/CartSidebar.vue
+++ b/packages/theme/components/CartSidebar.vue
@@ -70,8 +70,8 @@
                     />
                   </div>
                 </template>
-                <!-- @TODO: remove if https://github.com/vuestorefront/storefront-ui/issues/2022 is done -->
-                <template #more-actions>{{  }}</template>
+                 <template #actions="{}">&nbsp;</template>
+                 <template #more-actions>&nbsp;</template>
               </SfCollectedProduct>
             </transition-group>
           </div>

--- a/packages/theme/components/CartSidebar.vue
+++ b/packages/theme/components/CartSidebar.vue
@@ -34,15 +34,15 @@
                 :class="`collected-product status-${cartGetters.getItemStatus(product)}`"
               >
                 <template #price>
-                <SfPrice
-                  :regular="cartGetters.getItemPrice(product).regular && $n(cartGetters.getItemPrice(product).regular, 'currency')"
-                  :special="cartGetters.getItemPrice(product).special && $n(cartGetters.getItemPrice(product).special, 'currency')"
-                />
-                <SfProperty
-                      name="Total"
-                      :value="$n(cartGetters.getItemTotals(product).total, 'currency')"
-                />
-      </template>
+                  <SfPrice
+                    :regular="cartGetters.getItemPrice(product).regular && $n(cartGetters.getItemPrice(product).regular, 'currency')"
+                    :special="cartGetters.getItemPrice(product).special && $n(cartGetters.getItemPrice(product).special, 'currency')"
+                  />
+                  <SfProperty
+                        name="Total"
+                        :value="$n(cartGetters.getItemTotals(product).total, 'currency')"
+                  />
+                </template>
                 <template #configuration>
                   <div class="collected-product__properties">
 
@@ -223,19 +223,6 @@ export default {
   &__saving {
     margin-bottom: var(--spacer-base);
   }
-}
-
-.rewards-title {
-  --heading-title-color: var(--c-warning);
-  padding-bottom: var(--spacer-xs);
-}
-
-.property-reward {
-  color: var(--c-warning);
-  &:last-child {
-    padding-bottom: var(--spacer-xs);
-  }
-
 }
 
 .empty-cart {

--- a/packages/theme/components/Checkout/CartPreview.vue
+++ b/packages/theme/components/Checkout/CartPreview.vue
@@ -41,7 +41,7 @@
         :value="$n(cartGetters.getShippingPrice(cart), 'currency')"
         :class="['sf-property--full-width', 'sf-property--small property']"
       />
-    
+
       <SfProperty
         :name="$t('Total')"
         :value="$n(totals.total, 'currency')"
@@ -66,26 +66,25 @@
 
 <script>
 import { SfHeading, SfProperty, SfCharacteristic } from '@storefront-ui/vue';
-import  CartSaving from './CartSaving'
-import { computed, ref, defineComponent, useRouter } from '@nuxtjs/composition-api';
+import CartSaving from './CartSaving';
+import { computed, useRouter } from '@nuxtjs/composition-api';
 import { useCart, cartGetters} from '@vue-storefront/orc-vsf';
-    const CHARACTERISTICS = [
+const CHARACTERISTICS = [
   {
     title: 'Safety',
     description: 'It carefully packaged with a personal touch',
-    icon: 'safety',
+    icon: 'safety'
   },
   {
     title: 'Easy shipping',
     description: 'You’ll receive dispatch confirmation and an arrival date',
-    icon: 'shipping',
+    icon: 'shipping'
   }
 ];
 
-
 export default {
   name: 'CartPreview',
-    components: {
+  components: {
     SfHeading,
     SfProperty,
     SfCharacteristic,
@@ -96,12 +95,11 @@ export default {
     const router = useRouter();
     const { locale } = router.app.$i18n;
     const totalItems = computed(() => cartGetters.getTotalItems(cart.value));
-    const items = computed(() => cartGetters.getItems(cart.value));
     const isActiveShippingTaxable = computed(() => cartGetters.isActiveShippingTaxable(cart.value));
     const isActiveShippingEstimated = computed(() => cartGetters.isActiveShippingEstimated(cart.value));
     const taxes = computed(() => cartGetters.getTaxes(cart.value));
     const totals = computed(() => cartGetters.getTotals(cart.value));
-return {
+    return {
       cartGetters,
       cart,
       totalItems,
@@ -111,9 +109,9 @@ return {
       isActiveShippingEstimated,
       locale,
       characteristics: CHARACTERISTICS
-    }
+    };
   }
-}
+};
 </script>
 <style lang="scss" scoped>
 .highlighted {

--- a/packages/theme/components/Checkout/CartPreview.vue
+++ b/packages/theme/components/Checkout/CartPreview.vue
@@ -1,0 +1,156 @@
+<template>
+  <div>
+    <div class="highlighted">
+      <SfHeading
+        :level="3"
+        :title="$t('Order summary')"
+        class="sf-heading--left sf-heading--no-underline title"
+      />
+    </div>
+    <div class="highlighted">
+      <SfProperty
+        :name="$t('Products')"
+        :value="totalItems"
+        class="sf-property--full-width sf-property--large property"
+      />
+
+      <SfProperty
+        :name="$t('Subtotal')"
+        :value="$n(totals.subtotal, 'currency')"
+        :class="['sf-property--full-width', 'sf-property--large property']"
+      />
+
+      <SfProperty
+        v-if="isActiveShippingTaxable && isActiveShippingEstimate"
+        :name="$t('Shipping')"
+        :value="$n(cartGetters.getShippingPrice(cart), 'currency')"
+        :class="['sf-property--full-width', 'sf-property--small property']"
+      />
+
+      <SfProperty
+        v-for="(tax, i) in taxes"
+        :key="i"
+        :name="tax.displayName[locale]"
+        :value="$n(tax.taxTotal, 'currency')"
+        :class="['sf-property--full-width', 'sf-property--small property']"
+      />
+
+      <SfProperty
+        v-if="!isActiveShippingTaxable && isActiveShippingEstimated"
+        :name="$t('Shipping')"
+        :value="$n(cartGetters.getShippingPrice(cart), 'currency')"
+        :class="['sf-property--full-width', 'sf-property--small property']"
+      />
+    
+      <SfProperty
+        :name="$t('Total')"
+        :value="$n(totals.total, 'currency')"
+        class="sf-property--full-width sf-property--large property property-total"
+      />
+
+      <CartSaving class="cart-saving"/>
+
+    </div>
+    <div class="highlighted">
+      <SfCharacteristic
+        v-for="characteristic in characteristics"
+        :key="characteristic.title"
+        :title="characteristic.title"
+        :description="characteristic.description"
+        :icon="characteristic.icon"
+        class="characteristic"
+      />
+    </div>
+  </div>
+</template>
+
+<script>
+import { SfHeading, SfProperty, SfCharacteristic } from '@storefront-ui/vue';
+import  CartSaving from './CartSaving'
+import { computed, ref, defineComponent, useRouter } from '@nuxtjs/composition-api';
+import { useCart, cartGetters} from '@vue-storefront/orc-vsf';
+    const CHARACTERISTICS = [
+  {
+    title: 'Safety',
+    description: 'It carefully packaged with a personal touch',
+    icon: 'safety',
+  },
+  {
+    title: 'Easy shipping',
+    description: 'You’ll receive dispatch confirmation and an arrival date',
+    icon: 'shipping',
+  }
+];
+
+
+export default {
+  name: 'CartPreview',
+    components: {
+    SfHeading,
+    SfProperty,
+    SfCharacteristic,
+    CartSaving
+  },
+  setup() {
+    const { cart } = useCart();
+    const router = useRouter();
+    const { locale } = router.app.$i18n;
+    const totalItems = computed(() => cartGetters.getTotalItems(cart.value));
+    const items = computed(() => cartGetters.getItems(cart.value));
+    const isActiveShippingTaxable = computed(() => cartGetters.isActiveShippingTaxable(cart.value));
+    const isActiveShippingEstimated = computed(() => cartGetters.isActiveShippingEstimated(cart.value));
+    const taxes = computed(() => cartGetters.getTaxes(cart.value));
+    const totals = computed(() => cartGetters.getTotals(cart.value));
+return {
+      cartGetters,
+      cart,
+      totalItems,
+      totals,
+      taxes,
+      isActiveShippingTaxable,
+      isActiveShippingEstimated,
+      locale,
+      characteristics: CHARACTERISTICS
+    }
+  }
+}
+</script>
+<style lang="scss" scoped>
+.highlighted {
+  box-sizing: border-box;
+  width: 100%;
+  background-color: var(--c-light);
+  padding: var(--spacer-xl) var(--spacer-xl) 0;
+  &:last-child {
+    padding-bottom: var(--spacer-xl);
+  }
+}
+.cart-saving {
+  margin-left: -15px;
+  margin-right: -15px;
+}
+.total-items {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--spacer-xl);
+}
+.property {
+  margin-bottom: var(--spacer-base);
+}
+.property-total {
+  margin-top: var(--spacer-xl);
+  padding-top: var(--spacer-lg);
+  padding-bottom: var(--spacer-base);
+  font-size: var(--font-size-xl);
+  border-top: var(--c-white) 1px solid;
+  --property-name-font-weight: var(--font-weight--semibold);
+  --property-name-color: var(--c-text);
+}
+
+.characteristic {
+  &:not(:last-child) {
+    margin-bottom: var(--spacer-base);
+  }
+}
+</style>

--- a/packages/theme/components/Checkout/CartPreview.vue
+++ b/packages/theme/components/Checkout/CartPreview.vue
@@ -79,6 +79,11 @@ const CHARACTERISTICS = [
     title: 'Easy shipping',
     description: 'You’ll receive dispatch confirmation and an arrival date',
     icon: 'shipping'
+  },
+  {
+    title: 'Fees',
+    description: 'Additional fees may apply in case of oversized packages.',
+    icon: 'info'
   }
 ];
 

--- a/packages/theme/components/Checkout/CartSaving.vue
+++ b/packages/theme/components/Checkout/CartSaving.vue
@@ -13,6 +13,7 @@
         </div>
       </template>
       <SfProperty
+        v-if="productsDiscountAmount > 0"
         :name="$t('Items savings')"
         :value="$n(productsDiscountAmount, 'currency')"
         :class="['sf-property--full-width', 'sf-property--small property']"

--- a/packages/theme/components/Checkout/CartSaving.vue
+++ b/packages/theme/components/Checkout/CartSaving.vue
@@ -11,12 +11,12 @@
             class="sf-property--full-width sf-property--large property-saving-total"
           />
         </div>
-      </template>   
+      </template>
       <SfProperty
         :name="$t('Items savings')"
         :value="$n(productsDiscountAmount, 'currency')"
         :class="['sf-property--full-width', 'sf-property--small property']"
-      />  
+      />
       <div v-if="hasRewards">
         <SfProperty
             v-for="(reward, i) in rewards"
@@ -34,30 +34,29 @@
 
 <script>
 import { SfHeading, SfProperty, SfAccordion } from '@storefront-ui/vue';
-import { computed, ref, defineComponent, useRouter } from '@nuxtjs/composition-api';
+import { computed } from '@nuxtjs/composition-api';
 import { useCart, cartGetters} from '@vue-storefront/orc-vsf';
-
 
 export default {
   name: 'CartSaving',
-    components: {
+  components: {
     SfHeading,
     SfProperty,
-    SfAccordion 
+    SfAccordion
   },
   setup() {
     const { cart } = useCart();
     const items = computed(() => cartGetters.getItems(cart.value));
-    const rewards = computed(() => cartGetters.getRewards(cart.value)); 
+    const rewards = computed(() => cartGetters.getRewards(cart.value));
     const hasRewards = computed(() => rewards.value?.length > 0);
     const discounts = computed(() => cartGetters.getDiscounts(cart.value));
     const totals = computed(() => cartGetters.getTotals(cart.value));
     const productsDiscountAmount = computed(
-          () => items.value?.reduce((a, el) => (el.defaultPrice - el.currentPrice) * el.quantity + a, 0),
+      () => items.value?.reduce((a, el) => ((el.defaultPrice - el.currentPrice) * el.quantity) + a, 0)
     );
     const totalDiscountsAmount = computed(() => totals.value?.discount + productsDiscountAmount.value);
     const hasDiscounts = computed(() => totalDiscountsAmount.value > 0);
-return {
+    return {
       cartGetters,
       cart,
       rewards,
@@ -66,9 +65,9 @@ return {
       productsDiscountAmount,
       totalDiscountsAmount,
       hasDiscounts
-    }
+    };
   }
-}
+};
 </script>
 <style lang="scss" scoped>
 .cart-saving {

--- a/packages/theme/components/Checkout/CartSaving.vue
+++ b/packages/theme/components/Checkout/CartSaving.vue
@@ -1,0 +1,93 @@
+<template>
+  <div class="cart-saving" v-if="hasDiscounts">
+  <SfAccordion :multiple="false" transition="" showChevron>
+    <SfAccordionItem header="Total">
+      <template #header="{accordionClick}">
+        <div @click="accordionClick" :style="{cursor: 'pointer'}">
+          <SfProperty
+            v-if="hasDiscounts"
+            :name="$t('Total savings')"
+            :value="$n(totalDiscountsAmount, 'currency')"
+            class="sf-property--full-width sf-property--large property-saving-total"
+          />
+        </div>
+      </template>   
+      <SfProperty
+        :name="$t('Items savings')"
+        :value="$n(productsDiscountAmount, 'currency')"
+        :class="['sf-property--full-width', 'sf-property--small property']"
+      />  
+      <div v-if="hasRewards">
+        <SfProperty
+            v-for="(reward, i) in rewards"
+            :key="i"
+            :name="reward.promotionName"
+            :value="$n(reward.amount, 'currency')"
+            :class="['sf-property--full-width', 'sf-property--small property']"
+          />
+      </div>
+    </SfAccordionItem>
+  </SfAccordion>
+  </div>
+
+</template>
+
+<script>
+import { SfHeading, SfProperty, SfAccordion } from '@storefront-ui/vue';
+import { computed, ref, defineComponent, useRouter } from '@nuxtjs/composition-api';
+import { useCart, cartGetters} from '@vue-storefront/orc-vsf';
+
+
+export default {
+  name: 'CartSaving',
+    components: {
+    SfHeading,
+    SfProperty,
+    SfAccordion 
+  },
+  setup() {
+    const { cart } = useCart();
+    const items = computed(() => cartGetters.getItems(cart.value));
+    const rewards = computed(() => cartGetters.getRewards(cart.value)); 
+    const hasRewards = computed(() => rewards.value?.length > 0);
+    const discounts = computed(() => cartGetters.getDiscounts(cart.value));
+    const totals = computed(() => cartGetters.getTotals(cart.value));
+    const productsDiscountAmount = computed(
+          () => items.value?.reduce((a, el) => (el.defaultPrice - el.currentPrice) * el.quantity + a, 0),
+    );
+    const totalDiscountsAmount = computed(() => totals.value?.discount + productsDiscountAmount.value);
+    const hasDiscounts = computed(() => totalDiscountsAmount.value > 0);
+return {
+      cartGetters,
+      cart,
+      rewards,
+      hasRewards,
+      discounts,
+      productsDiscountAmount,
+      totalDiscountsAmount,
+      hasDiscounts
+    }
+  }
+}
+</script>
+<style lang="scss" scoped>
+.cart-saving {
+  background-color: var(--c-light);
+  padding: var(--spacer-xs);
+  border: solid 1px var(--c-primary);
+}
+
+.property {
+  --property-value-font-weight: var(--font-weight--normal);
+}
+
+.property-saving-total {
+  color: var(--c-primary);
+  --property-value-font-weight: var(--font-weight--medium);
+}
+
+.property-discount {
+  color: var(--c-primary);
+  padding-bottom: var(--spacer-xs);
+}
+</style>

--- a/packages/theme/components/Checkout/CartSaving.vue
+++ b/packages/theme/components/Checkout/CartSaving.vue
@@ -13,9 +13,9 @@
         </div>
       </template>
       <SfProperty
-        v-if="productsDiscountAmount > 0"
+        v-if="itemsDiscountsAmount > 0"
         :name="$t('Items savings')"
-        :value="$n(productsDiscountAmount, 'currency')"
+        :value="$n(itemsDiscountsAmount, 'currency')"
         :class="['sf-property--full-width', 'sf-property--small property']"
       />
       <div v-if="hasRewards">
@@ -47,23 +47,19 @@ export default {
   },
   setup() {
     const { cart } = useCart();
-    const items = computed(() => cartGetters.getItems(cart.value));
     const rewards = computed(() => cartGetters.getRewards(cart.value));
     const hasRewards = computed(() => rewards.value?.length > 0);
-    const discounts = computed(() => cartGetters.getDiscounts(cart.value));
+    const itemsDiscountsAmount = computed(() => cartGetters.getItemsDiscountsAmount(cart.value));
     const totals = computed(() => cartGetters.getTotals(cart.value));
-    const productsDiscountAmount = computed(
-      () => items.value?.reduce((a, el) => ((el.defaultPrice - el.currentPrice) * el.quantity) + a, 0)
-    );
-    const totalDiscountsAmount = computed(() => totals.value?.discount + productsDiscountAmount.value);
+
+    const totalDiscountsAmount = computed(() => totals.value?.discount + itemsDiscountsAmount.value);
     const hasDiscounts = computed(() => totalDiscountsAmount.value > 0);
     return {
       cartGetters,
       cart,
       rewards,
       hasRewards,
-      discounts,
-      productsDiscountAmount,
+      itemsDiscountsAmount,
       totalDiscountsAmount,
       hasDiscounts
     };


### PR DESCRIPTION
Checkout Order Summary with Tax, Shipping, Savings

## Description
Implement component to display checkout order summary with Taxes, Shipping, Totals
Implement component to display Cart Saving (items savings, rewards)

## Related Issue
[AB#61784](https://dev.azure.com/orckestra001/da965986-c85b-43be-9915-219568b000e5/_workitems/edit/61784)

## Motivation and Context
Ability to see detailed order summary on checkout 

## How Has This Been Tested?
On Checkout page the Order Summary section

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/6649972/174822030-6afdf906-d33c-4882-8cb8-1e2b2d3751a5.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
