### PR TITLE
fix: first load of wishlist for guest

### DIFF
--- a/packages/composables/src/useWishlist/index.ts
+++ b/packages/composables/src/useWishlist/index.ts
@@ -10,8 +10,8 @@ import { getVariantId } from '../helpers/productUtils';
 const params: UseWishlistFactoryParams<Wishlist, WishlistItem, Product> = {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   load: async (context: Context) => {
-    const items = await context.$occ.api.getCartLineItems({ cartName: 'Wishlist' });
-    return { items: items || [] };
+    const wishlist = await context.$occ.api.getCart({ cartName: 'Wishlist' });
+    return { items: wishlist?.items || [] };
   },
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/theme/lang/en.js
+++ b/packages/theme/lang/en.js
@@ -118,6 +118,7 @@ export default {
   'Your bag is empty': 'Your bag is empty',
   'Cancel': 'Cancel',
   'See all results': 'See all results',
+  'See all': 'See all',
   'We haven’t found any results for given phrase': 'We haven’t found any results for given phrase',
   'You haven’t searched for items yet': 'You haven’t searched for items yet.',
   'Let’s start now – we’ll help you': 'Let’s start now – we’ll help you.',


### PR DESCRIPTION
Use getCart request to load wishlist instead of getCartLineItems
The difference is that getCart will create new cart if absent, the getCartLineItems will throw 400 error
[AB#63380](https://dev.azure.com/orckestra001/da965986-c85b-43be-9915-219568b000e5/_workitems/edit/63380)