### PR TITLE
fix: order details not showing address name

### DIFF
--- a/packages/theme/components/AddressPreview.vue
+++ b/packages/theme/components/AddressPreview.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="address-preview" v-if="address">
     <span v-if="address.addressName && showAddressName" class="sf-property__value address-preview-name">{{address.addressName}}</span>
-    <span v-if="address.firstName && showName">{{`${address.firstName} ${address.lastName}`}}</span>
+    <span v-if="address.firstName && showName">{{`${address.firstName} ${address.lastName ? address.lastName : ''}`}}</span>
     <span v-if="address.city">{{`${address.city}, ${address.line1 ? address.line1 : ''} ${address.line2 ? address.line2 : ''}`}}</span>
     <span v-if="address.regionCode">{{`${countriesGetters.getCountryRegionName(countries, address.countryCode, address.regionCode)}, ${address.postalCode}`}}</span>
     <span v-if="address.countryCode">{{`${countriesGetters.getCountryName(countries, address.countryCode)}`}}</span>

--- a/packages/theme/pages/MyAccount/OrderHistory.vue
+++ b/packages/theme/pages/MyAccount/OrderHistory.vue
@@ -166,7 +166,7 @@
                   :name="`${currentOrderShipping.type} address`"
                   class="sf-property">
                   <template #value>
-                    <AddressPreview :address="currentOrderShipping.address" />
+                    <AddressPreview :address="currentOrderShipping.address" :showAddressName="false"/>
                   </template>
                 </SfProperty>
             </div>
@@ -185,7 +185,7 @@
                   name="Billing address"
                   class="sf-property">
                   <template #value>
-                    <AddressPreview :address="orderGetters.getPaymentAddress(currentOrder)" />
+                    <AddressPreview :address="orderGetters.getPaymentAddress(currentOrder)" :showAddressName="false"/>
                   </template>
                 </SfProperty>
             </div>


### PR DESCRIPTION
fix: order details not showing address name

## Description
fixed order details not showing address name

## Related Issue
[AB#64332](https://dev.azure.com/orckestra001/da965986-c85b-43be-9915-219568b000e5/_workitems/edit/64332)

## How Has This Been Tested?
create order, go to the order details page

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
