### PR TITLE
fix: workaround  for sfcomponentselect issue  inside content pages

### DIFF
--- a/packages/theme/components/AddressForm.vue
+++ b/packages/theme/components/AddressForm.vue
@@ -86,11 +86,7 @@
           required
           :valid="!errors[0]"
           :error-message="errors[0]"
-          class="
-            sf-component-select--underlined
-            form__select
-            form__element--half
-            form__element--half-even">
+          class="sf-component-select--underlined">
           <SfComponentSelectOption
             v-for="{isoCode, name} in countries"
             :key="isoCode"
@@ -111,11 +107,7 @@
           required
           :valid="!errors[0]"
           :error-message="errors[0]"
-          class="
-            sf-component-select--underlined
-            form__select
-            form__element--half
-            form__element--half-even">
+          class="sf-component-select--underlined">
             <SfComponentSelectOption
               v-for="{isoCode, name} in getRegions(form.countryCode)"
               :key="isoCode"
@@ -211,6 +203,7 @@ export default {
 };
 </script>
 <style lang='scss' scoped>
+
 .form {
   &__element {
     flex: 1 0 100%;

--- a/packages/theme/layouts/default.vue
+++ b/packages/theme/layouts/default.vue
@@ -84,7 +84,12 @@ export default {
 
 <style lang="scss">
 @import "~@storefront-ui/vue/styles";
-
+:root {
+  .sf-tabs__content__tab {
+    // workaround for issue https://github.com/vuestorefront/storefront-ui/issues/2491
+    transform: translate3d(0, 0, 0);
+  }
+}
 #layout {
   box-sizing: border-box;
   @include for-desktop {


### PR DESCRIPTION
Workaround  for issue  https://github.com/vuestorefront/storefront-ui/issues/2491

[AB#65768](https://dev.azure.com/orckestra001/da965986-c85b-43be-9915-219568b000e5/_workitems/edit/65768)

