### PR TITLE
feat: mega menu

### DIFF
--- a/packages/theme/components/HeaderNavigation.vue
+++ b/packages/theme/components/HeaderNavigation.vue
@@ -1,14 +1,26 @@
 <template>
-<div>
+<div >
   <div class="sf-header__navigation desktop desktop-only">
-    <SfHeaderNavigationItem
-      v-for="(menu, index) in menus"
-      :key="index"
-      class="nav-item"
-      v-e2e="`app-header-url_${menu.slug}`"
-      :label="menu.label"
-      :link="localePath(`/c/${menu.slug}`)"
-    />
+    <div class="header-navigation" @mouseleave="hideSubcategories"
+      >
+      <SfHeaderNavigationItem
+        v-for="(menu, index) in menus"
+        :key="index"
+        ref="lvl0CatRefs"
+        class="nav-item"
+        v-e2e="`app-header-url_${menu.slug}`"
+        :label="menu.label"
+        :data-index="index"
+        @click.native="setCurrentCategory(null)"
+        @mouseenter.native.prevent="onMouseEnter(menu)"
+        keyup.tab.native.prevent="setFocus($event)"
+        @keydown.up.native.prevent="setCurrentCategory(null)"
+        @keydown.down.native.prevent="setCurrentCategory(menu)"
+        :link="localePath(`/c/${menu.slug}`)"
+      />
+      <HeaderNavigationSubcategories :currentCategory="currentCategory"
+          @hideSubcategories="hideSubcategories"  />
+    </div>
   </div>
   <div class="smartphone-only">
   <SfModal :visible="isMobileMenuOpen">
@@ -27,40 +39,78 @@
 </template>
 
 <script>
+import { computed, ref } from '@nuxtjs/composition-api';
 import { SfMenuItem, SfModal } from '@storefront-ui/vue';
 import { useUiState, useUiHelpers } from '~/composables';
 import { useCategory, categoryGetters } from '@vue-storefront/orc-vsf';
-import { computed } from '@nuxtjs/composition-api';
 import { onSSR } from '@vue-storefront/core';
+import HeaderNavigationSubcategories from './HeaderNavigationSubcategories.vue';
 
 export default {
   name: 'HeaderNavigation',
   components: {
     SfMenuItem,
-    SfModal
+    SfModal,
+    HeaderNavigationSubcategories
   },
   setup() {
     const { isMobileMenuOpen, toggleMobileMenu } = useUiState();
     const { search: searchCategories, categories, loading } = useCategory('categories');
     const th = useUiHelpers();
+    const currentCategory = ref(null);
+    const hasFocus = ref(false);
+    let focusedElement = null;
 
     onSSR(async () => {
       await searchCategories({});
     });
 
-    const menus = computed(() => categoryGetters.getCategoryTree(categories.value, th.getFacetsFromURL()?.categorySlug, 1)?.items.slice(0, 5));
+    const menus = computed(() => categoryGetters.getCategoryTree(categories.value, th.getFacetsFromURL()?.categorySlug, 3)?.items.slice(0, 5));
+
+    const setCurrentCategory = (category) => {
+      currentCategory.value = category;
+    };
+
+    const setFocus = (event) => {
+      focusedElement = event.target;
+      hasFocus.value = true;
+    };
+
+    const onMouseEnter = (category) => {
+      setCurrentCategory(category);
+      hasFocus.value = false;
+    };
+
+    const hideSubcategories = () => {
+      setCurrentCategory(null);
+      if (focusedElement !== null) focusedElement.focus();
+    };
 
     return {
       menus,
       loading,
       isMobileMenuOpen,
-      toggleMobileMenu
+      toggleMobileMenu,
+      onMouseEnter,
+      setFocus,
+      currentCategory,
+      setCurrentCategory,
+      hideSubcategories
     };
   }
 };
 </script>
 
 <style lang="scss" scoped>
+.header-navigation {
+  display: flex;
+
+  .nav-item {
+      &:hover {
+        color: var(--c-primary);
+      }
+  }
+}
 .sf-header-navigation-item {
   ::v-deep &__item--mobile {
     display: block;

--- a/packages/theme/components/HeaderNavigationSubcategories.vue
+++ b/packages/theme/components/HeaderNavigationSubcategories.vue
@@ -1,0 +1,223 @@
+<template>
+  <div
+    v-if="hasChildren(currentCategory)"
+    data-testid="navigation-subcategories"
+    class="header-navigation__subcategories"
+  >
+    <div class="header-navigation__subcategories-inner">
+      <div
+        v-for="(itemLvl1, idxLvl1) in currentCategory.items"
+        :key="idxLvl1"
+        class="header-navigation__subcategory"
+        aria-haspopup="true"
+      >
+        <SfLink
+          ref="lvl1CatRefs"
+          class="header-navigation__link1"
+          :link="localePath(getCatLink(itemLvl1))"
+          :data-children="itemLvl1.items.length"
+          @click.native="$emit('hideSubcategories')"
+          @keydown.right.native.prevent="onKeyRight()"
+          @keydown.left.native.prevent="onKeyLeft()"
+          @keydown.down.native.prevent="onKeyDown()"
+          @keydown.up.native.prevent="onKeyUp()"
+        >
+          <h2 class="sf-heading sf-heading--left sf-heading sf-heading--left header-navigation__lvl1link">
+            {{ itemLvl1.label }}
+          </h2>
+        </SfLink>
+        <SfList v-if="hasChildren(itemLvl1)">
+          <SfListItem
+            v-for="(itemLvl2, idxLvl2) in itemLvl1.items"
+            :key="idxLvl2"
+          >
+            <SfLink
+              ref="lvl2CatRefs"
+              class="header-navigation__lvl2link"
+              :link="localePath(getCatLink(itemLvl2))"
+              tabindex="-1"
+              @click.native="$emit('hideSubcategories')"
+              @keydown.right.native.prevent="onKeyRight()"
+              @keydown.left.native.prevent="onKeyLeft()"
+              @keydown.down.native.prevent="onKeyDown()"
+              @keydown.up.native.prevent="onKeyUp()"
+                 >
+              {{ itemLvl2.label }}
+            </SfLink>
+          </SfListItem>
+        </SfList>
+      </div>
+    </div>
+  </div>
+</template>
+<script>
+import {
+  SfLink, SfList
+} from '@storefront-ui/vue';
+import { useCategory, categoryGetters } from '@vue-storefront/orc-vsf';
+import { useUiHelpers } from '~/composables';
+import { defineComponent, onMounted, ref } from '@nuxtjs/composition-api';
+
+export default defineComponent({
+  name: 'HeaderNavigationSubcategories',
+  components: {
+    SfLink,
+    SfList
+  },
+  props: {
+    currentCategory: {
+      type: Object,
+      default() {
+        return null;
+      }
+    },
+    hasFocus: {
+      type: Boolean,
+      default: false
+    }
+  },
+  setup(props, { emit }) {
+    const { categories } = useCategory('categories');
+    const { getCatLink } = useUiHelpers();
+    const lvl1CatRefs = ref();
+    const lvl2CatRefs = ref();
+    const lvl2GroupedCatRefs = ref();
+
+    let lvl1CatFocusIdx = 0;
+    let lvl2CatFocusIdx = -1;
+
+    const getGroupedLvl2CatRefs = () => {
+      let current = 0;
+      const result = [];
+      lvl1CatRefs.value.forEach((lvl1CatRef) => {
+        const groupCount = Number(lvl1CatRef.$el.dataset.children);
+        const group = lvl2CatRefs.value.slice(current, current + groupCount);
+        result.push(group);
+        current += groupCount;
+      });
+      return result;
+    };
+
+    const subCategories = (current) => categoryGetters.getCategoryTree(categories.value, current, 2);
+
+    const hasChildren = (category) => Boolean(category?.items?.length > 0);
+
+    const onKeyRight = () => {
+      if (lvl1CatRefs.value[++lvl1CatFocusIdx]) {
+        lvl1CatRefs.value[lvl1CatFocusIdx].$el.focus();
+        lvl2CatFocusIdx = -1;
+        lvl2GroupedCatRefs.value = getGroupedLvl2CatRefs();
+      } else {
+        lvl1CatFocusIdx--;
+      }
+    };
+    const onKeyLeft = () => {
+      if (lvl1CatRefs.value[--lvl1CatFocusIdx]) {
+        lvl1CatRefs.value[lvl1CatFocusIdx].$el.focus();
+        lvl2CatFocusIdx = -1;
+        lvl2GroupedCatRefs.value = getGroupedLvl2CatRefs();
+      } else {
+        lvl1CatFocusIdx++;
+      }
+    };
+    const onKeyDown = () => {
+      lvl2CatFocusIdx++;
+      if (lvl2CatFocusIdx !== -1 && !lvl2GroupedCatRefs.value[lvl1CatFocusIdx][lvl2CatFocusIdx]) {
+        lvl2CatFocusIdx--;
+        return;
+      }
+      lvl2GroupedCatRefs.value[lvl1CatFocusIdx][lvl2CatFocusIdx].$el.focus();
+    };
+    const onKeyUp = () => {
+      if (lvl2CatFocusIdx > 0) {
+        lvl2CatFocusIdx--;
+        lvl2GroupedCatRefs.value[lvl1CatFocusIdx][lvl2CatFocusIdx].$el.focus();
+        return;
+      }
+      if (lvl2CatFocusIdx === 0) {
+        lvl1CatRefs.value[lvl1CatFocusIdx].$el.focus();
+        lvl2CatFocusIdx = -1;
+        return;
+      }
+      if (lvl2CatFocusIdx === -1) {
+        emit('hideSubcategories');
+      }
+    };
+
+    const setupNavIndexes = () => {
+      lvl2CatFocusIdx = -1;
+      lvl1CatRefs.value[lvl1CatFocusIdx].$el.focus();
+      lvl2GroupedCatRefs.value = getGroupedLvl2CatRefs();
+    };
+
+    onMounted(() => {
+      if (props.hasFocus) {
+        setupNavIndexes();
+      }
+    });
+
+    return {
+      getCatLink,
+      hasChildren,
+      subCategories,
+      onKeyRight,
+      onKeyLeft,
+      onKeyDown,
+      onKeyUp,
+      setupNavIndexes,
+      lvl1CatRefs,
+      lvl2CatRefs
+    };
+  }
+});
+</script>
+<style lang="scss" scoped>
+.header-navigation {
+  &__subcategories {
+    position: absolute;
+    z-index: 1;
+    background-color: var(--_c-light-primary);
+    box-shadow: rgba(50, 50, 93, 0.25) 0px 6px 12px -2px, rgba(0, 0, 0, 0.3) 0px 3px 7px -3px;
+    left: 0;
+    padding: 30px;
+    right: 0;
+    top: 84px;
+    flex-wrap: wrap;
+    justify-content: center;
+    display: flex;
+
+    &-inner {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: flex-start;
+      width: var(--header-width, 77.5rem);
+    }
+  }
+
+  &__subcategory {
+    flex: 0 0 25%;
+     margin-bottom: var(--spacer-base);
+  }
+
+  &__lvl1link {
+      font-size: var(--h5-font-size);
+      text-decoration: none;
+      &:hover {
+        color: var(--c-primary);
+      }
+  }
+
+  &__lvl2link {
+    &:hover {
+      color: var(--c-primary);
+    }
+  }
+
+  .sf-link {
+    text-decoration: none;
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}
+</style>

--- a/packages/theme/pages/Category.vue
+++ b/packages/theme/pages/Category.vue
@@ -55,6 +55,7 @@
                         <template #label>
                           <nuxt-link
                             :to="localePath(th.getCatLink(cat))"
+                            class="sidebar--cat"
                             :class="cat.isCurrent ? 'sidebar--cat-selected' : ''"
                           >
                             All
@@ -73,6 +74,7 @@
                       >
                         <template #label="{ label }">
                           <nuxt-link
+                            class="sidebar--cat"
                             :to="localePath(th.getCatLink(subCat))"
                             :class="subCat.isCurrent ? 'sidebar--cat-selected' : ''"
                           >
@@ -483,6 +485,10 @@ export default {
   padding: var(--spacer-sm);
   border: 1px solid var(--c-light);
   border-width: 0 1px 0 0;
+
+  &--cat {
+    text-align: left;
+  }
 }
 .loading {
   margin: var(--spacer-3xl) auto;


### PR DESCRIPTION
Mega menu with 2cd level of categories

## Description
Mega menu with 2cd level of categories for Mobile and Desktop

## Related Issue
AB#65219

## Motivation and Context
Ability quickly navigate to needed category page

## How Has This Been Tested?
Desktop and Mobile mega menus

## Screenshots (if appropriate):
![WLf5upHwqL](https://user-images.githubusercontent.com/6649972/190148411-3417da9d-3335-4143-aa35-a795242d6e94.gif)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
